### PR TITLE
fix: improve menu titles and warning messages

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -45,5 +45,5 @@ Else
 	Download the tarball of this plugin
 	Uncompress it in the plugins directory of your glpi installation
 
-Once copied in the repertory, go the the "Configuration"->"Plugins"->"File injection" menu, and install the plugin
+Once copied in the repertory, go the the "Configuration"->"Plugins"->"Data injection" menu, and install the plugin
 

--- a/front/clientinjection.form.php
+++ b/front/clientinjection.form.php
@@ -31,7 +31,7 @@
 require '../../../inc/includes.php';
 
 Html::header(
-    __('File injection', 'datainjection'), $_SERVER["PHP_SELF"],
+    __('Data injection', 'datainjection'), $_SERVER["PHP_SELF"],
     "tools", "plugindatainjectionmenu", "client"
 );
 

--- a/front/popup.php
+++ b/front/popup.php
@@ -40,7 +40,7 @@ switch ($_GET["popup"]) {
     break;
 
    case "log" :
-       Html::popHeader(__('File injection report', 'datainjection'), $_SERVER['PHP_SELF']);
+       Html::popHeader(__('Data injection report', 'datainjection'), $_SERVER['PHP_SELF']);
        PluginDatainjectionModel::showLogResults($_GET['models_id']);
        Html::popFooter();
     break;

--- a/inc/clientinjection.class.php
+++ b/inc/clientinjection.class.php
@@ -142,7 +142,7 @@ class PluginDatainjectionClientInjection
    static function showUploadFileForm($options = []) {
 
       $add_form = (isset($options['add_form']) && $options['add_form']);
-      $confirm  = (isset($options['confirm']) && $options['confirm']);
+      $confirm  = (isset($options['confirm'])? $options['confirm'] : false);
       $url      = (($confirm == 'creation')?Toolbox::getItemTypeFormURL('PluginDatainjectionModel')
                                          :Toolbox::getItemTypeFormURL(__CLASS__));
       if ($add_form) {
@@ -167,9 +167,9 @@ class PluginDatainjectionClientInjection
       echo "<td colspan='2' class='center'>";
       if ($confirm) {
          if ($confirm == 'creation') {
-            $message = __('Warning : existing data will be overridden', 'datainjection');
+            $message = __s('Warning : existing mapped column will be overridden', 'datainjection');
          } else {
-            $message = __(
+            $message = __s(
               "Watch out, you're about to inject data into GLPI. Are you sure you want to do it ?",
               'datainjection'
             );

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -35,7 +35,7 @@ class PluginDatainjectionMenu extends CommonGLPI
 
    static function getMenuName() {
 
-      return __('File injection', 'datainjection');
+      return __('Data injection', 'datainjection');
    }
 
    static function getMenuContent() {

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -1514,7 +1514,7 @@ class PluginDatainjectionModel extends CommonDBTM
          $pdf->setHeader(
              sprintf(
                  __('%1$s (%2$s)'),
-                 __('File injection report', 'datainjection') . ' - <b>' .
+                 __('Data injection report', 'datainjection') . ' - <b>' .
                                  PluginDatainjectionSession::getParam('file_name') . '</b>',
                  $model->getName()
              )

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -64,7 +64,7 @@ class PluginDatainjectionProfile extends Profile
 
       if ($item->getType() == 'Profile') {
          if ($item->getField('interface') == 'central') {
-            return __('File injection', 'datainjection');
+            return __('Data injection', 'datainjection');
          }
          return '';
       }

--- a/setup.php
+++ b/setup.php
@@ -91,7 +91,7 @@ function plugin_init_datainjection() {
 function plugin_version_datainjection() {
 
    return [
-      'name'         => __('File injection', 'datainjection'),
+      'name'         => __('Data injection', 'datainjection'),
       'author'       => 'Walid Nouh, Remi Collet, Nelly Mahu-Lasson, Xavier Caillaud',
       'homepage'     => 'https://github.com/pluginsGLPI/datainjection',
       'license'      => 'GPLv2+',


### PR DESCRIPTION
- Rename "File injection" to "Data injection", closes #143 
- Improve warning text on model creation (internal 17549)
- The "Watch out..." text was never displayed (incorrect condition)
- The "Watch out..." text was not correctly escaped and didn't work (javascript error)

**Need to regenerate translations.**