### PR TITLE
fix(core): overload translation for antiviruse name

### DIFF
--- a/inc/computerinjection.class.php
+++ b/inc/computerinjection.class.php
@@ -68,6 +68,9 @@ class PluginDatainjectionComputerInjection extends Computer
       //Specific to location
       $tab[3]['linkfield'] = 'locations_id';
 
+      //specific for antiviruses
+      $tab[167]['name'] = __('Antivirus name', 'datainjection');
+
       //Remove some options because some fields cannot be imported
       $blacklist     = PluginDatainjectionCommonInjectionLib::getBlacklistedOptions(get_parent_class($this));
       $notimportable = [


### PR DESCRIPTION

this fix bad translation for computer fields 

list diplay two 'name' one for computer, other for antivirus

![image](https://user-images.githubusercontent.com/7335054/73268358-29041c80-41db-11ea-87b4-52564f18bdf9.png)

this PR fix this
