### PR TITLE
Prevent useless files to be packed into archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 .tx/                export-ignore
-locales/*.po        export-ignore
 locales/*.pot       export-ignore
 tools/              export-ignore
 .gitattributes      export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+.tx/                export-ignore
+locales/*.po        export-ignore
+locales/*.pot       export-ignore
+tools/              export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.travis.yml         export-ignore
+datainjection.xml   export-ignore
+RoboFile.php        export-ignore


### PR DESCRIPTION
Removal of useless files from archives is, for now, done by https://github.com/glpi-project/tools/blob/master/tools/plugin-release.

Using the `export-ignore` attribute for entries that should not be archived would be a better way to do this.
1. Each plugin may have a better control of list of files/patterns to ignore.
2. It is the standard way to do when creating archives using `git archive`.
3. Files will also be ignore from archived automatically produced by Github (see https://github.com/pluginsGLPI/datainjection/archive/d4edd4129759ddb3c5922a3bbb60b3f111e4be4d.zip for instance).
