### PR TITLE
fix(core): add slashes deep when validate model

### DIFF
--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -1248,6 +1248,7 @@ class PluginDatainjectionModel extends CommonDBTM
 
       $tmp         = $this->fields;
       $tmp['step'] = self::READY_TO_USE_STEP;
+      $tmp = Toolbox::addslashes_deep($tmp);
       $this->update($tmp);
    }
 


### PR DESCRIPTION
On validate model this warning show up

```
==> ../../files/_log/sql-errors.log <==
[2020-03-03 08:32:39] glpisqllog.ERROR: DBmysql::query() in /home/stanislas/Teclib/dev/GLPI/9.4-bugfixes/inc/dbmysql.class.php line 188
  *** MySQL query error:
  SQL: UPDATE `glpi_plugin_datainjection_models` SET `name` = 'test d'utilisateurdd' WHERE `id` = '7'
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'utilisateurdd' WHERE `id` = '7'' at line 1
  Backtrace :
  inc/dbmysql.class.php:948                          
  inc/commondbtm.class.php:616                       DBmysql->update()
  inc/commondbtm.class.php:1444                      CommonDBTM->updateInDB()
  plugins/datainjection/inc/model.class.php:1251     CommonDBTM->update()
  plugins/datainjection/front/model.form.php:72      PluginDatainjectionModel->switchReadyToUse()
  {"user":"2@stanislas-XPS-13-9343"} 

```

This PR prevent this.

See #192 