### PR TITLE
Remove entity specific code; fix #206

### DIFF
--- a/inc/entityinjection.class.php
+++ b/inc/entityinjection.class.php
@@ -65,7 +65,7 @@ class PluginDatainjectionEntityInjection extends Entity
 
       //Remove some options because some fields cannot be imported
       $blacklist     = PluginDatainjectionCommonInjectionLib::getBlacklistedOptions(get_parent_class($this));
-      $notimportable = [14, 26, 27, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+      $notimportable = [26, 27, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
                            42, 43, 44, 45, 47, 48, 49,50, 51, 52, 53, 54, 55, 91, 92, 93];
 
       $options['ignore_fields'] = array_merge($blacklist, $notimportable);
@@ -84,88 +84,6 @@ class PluginDatainjectionEntityInjection extends Entity
       $lib = new PluginDatainjectionCommonInjectionLib($this, $values, $options);
       $lib->processAddOrUpdate();
       return $lib->getInjectionResults();
-   }
-
-
-    /**
-    * @param $input     array
-    * @param $add                (true by default)
-    * @param $rights    array
-   **/
-   function customimport($input = [], $add = true, $rights = []) {
-
-      if (!isset($input['completename']) || empty($input['completename'])) {
-         return -1;
-      }
-
-      // Import a full tree from completename
-      $names  = explode('>', $input['completename']);
-      $fk     = $this->getForeignKeyField();
-      $i      = count($names);
-      $parent = 0;
-      $entity = new Entity();
-      $level  = 0;
-
-      foreach ($names as $name) {
-         $name = trim($name);
-         $i--;
-         $level++;
-         if (empty($name)) {
-            // Skip empty name (completename starting/endind with >, double >, ...)
-            continue;
-         }
-         $tmp['name'] = $name;
-
-         if (!$i) {
-            // Other fields (comment, ...) only for last node of the tree
-            foreach ($input as $key => $val) {
-               if ($key != 'completename') {
-                  $tmp[$key] = $val;
-               }
-            }
-         }
-         $tmp['level']       = $level;
-         $tmp['entities_id'] = $parent;
-
-         //Does the entity alread exists ?
-         $results = getAllDataFromTable(
-             'glpi_entities',
-             ['name' => $name, 'entities_id' => $parent]
-         );
-         //Entity doesn't exists => create it
-         if (empty($results)) {
-             $parent = CommonDropdown::import($tmp);
-         } else {
-             //Entity already exists, use the ID as parent
-             $ent    = array_pop($results);
-             $parent = $ent['id'];
-         }
-      }
-      return $parent;
-   }
-
-
-    /**
-    * @param $injectionClass
-    * @param $values
-    * @param $options
-   **/
-   function customDataAlreadyInDB($injectionClass, $values, $options) {
-
-      if (!isset($values['completename'])) {
-         return false;
-      }
-      $results = getAllDataFromTable(
-          'glpi_entities',
-          ['completename' => $values['completename']]
-      );
-
-      if (empty($results)) {
-          return false;
-      }
-
-       $ent    = array_pop($results);
-       return $ent['id'];
    }
 
 }


### PR DESCRIPTION
Internal ref: 20669.

Updating entities with datainjection doesn't work because of two issues.

1) Import / Update behaviors are inconsistent due to the `name` field being blacklisted

You end up being forced to use a config based on `completename` like this:
![image](https://user-images.githubusercontent.com/42734840/92601262-e3e5b400-f2ac-11ea-8518-561e752d6b30.png)

Then, using this CSV data:
```csv
entity;admin_email;phone
Import1;admin@import1.fr;0123456790
```

Creation will work, the new entity will be saved in the database like this: 
![image](https://user-images.githubusercontent.com/42734840/92601721-77b78000-f2ad-11ea-9406-c71c2cb8dda4.png)

However updates will not work as GLPI try to match the rows with this query:
```sql
SELECT * FROM `glpi_entities` WHERE `completename` = 'Import1'
```

This means that your csv need:
- "Import1" for creation
- "Root Entity > Import1" for updates

-> Fix: remove the `name` field from blacklist + delete the specific function `customDataAlreadyInDB` as it forces the search on `complename`.

2) The specific code does nothing for updates

```php
if (empty($results)) {
   $parent = CommonDropdown::import($tmp);
} else {
   //Entity already exists, use the ID as parent
   $ent    = array_pop($results);
   $parent = $ent['id'];
}
```

Creation is handled in the `if` block with `CommonDropdown::import`.
The `else` block is supposed to handle updates but does nothing besides assigning an id.

-> Fix: remove the specific `customimport` function.

Tested after removal with the `name` search options as the reconciliation key and creation + updates works without issue using the CSV example given earlier.
I don't really see why this specific code was needed, perhaps a constraint of an older GLPI version ?



