### PR TITLE
Drop not injectable fields before single linkfield workaround

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -2004,6 +2004,13 @@ class PluginDatainjectionCommonInjectionLib
          }
       }
 
+       // Drop not injectable fields
+       foreach ($type_searchOptions as $id => $tmp) {
+           if (!isset($tmp['injectable']) || $tmp['injectable'] <= 0) {
+               unset($type_searchOptions[$id]);
+           }
+       }
+
       foreach (['displaytype', 'checktype'] as $paramtype) {
          if (isset($options[$paramtype])) {
             foreach ($options[$paramtype] as $type => $tabsID) {

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -504,8 +504,9 @@ class PluginDatainjectionCommonInjectionLib
                $searchOption = self::findSearchOption($searchOptions, $field);
                //searchoption relation type is already manage by manageRelations()
                //skip it
-               if ((isset($searchOption['displaytype']) && $searchOption['displaytype'] != 'relation')
-                  || !isset($searchOption['displaytype'])) {
+               if ($searchOption !== false &&
+                   ((isset($searchOption['displaytype']) && $searchOption['displaytype'] != 'relation')
+                  || !isset($searchOption['displaytype']))) {
                      $this->getFieldValue($injectionClass, $itemtype, $searchOption, $field, $value);
                }
             }
@@ -1511,7 +1512,7 @@ class PluginDatainjectionCommonInjectionLib
 
       foreach ($values as $key => $value) {
          $option = self::findSearchOption($options, $key);
-         if (!isset($option['checktype']) || $option['checktype'] != self::FIELD_VIRTUAL) {
+         if ($option !== false && (!isset($option['checktype']) || $option['checktype'] != self::FIELD_VIRTUAL)) {
             //If field is a dropdown and value is '', then replace it by 0
             if (self::isFieldADropdown($option['displaytype']) && $value == self::EMPTY_VALUE) {
                $toinject[$key] = self::DROPDOWN_EMPTY_VALUE;


### PR DESCRIPTION
Since glpi-project/glpi#8816, there was a second search option with the same "users_id" link field. Then in the workaround for #121, the correct `User` option gets removed and the `Appliance User` option remains. This remaining option isn't injectable though and is dropped later anyways. It makes sense to drop all non-injectable options before the workaround.

fixes #259
fixes #243
fixes #233