### PR TITLE
fix(datainjection): preserve entities_id

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1521,6 +1521,10 @@ class PluginDatainjectionCommonInjectionLib
                $toinject[$key] = $value;
             }
          }
+
+         if ($key === 'entities_id') {
+            $toinject[$key] = $value;
+         }
       }
 
       $toinject = Toolbox::addslashes_deep($toinject);


### PR DESCRIPTION
Preserve ```entities_id``` (droped because related ```searchoption``` is blacklisted)

To prevent this error :

```shell
[2022-03-30 16:14:49] glpiphplog.NOTICE:   *** PHP Notice (8): Trying to access array offset on value of type bool in /home/stanislas/Teclib/dev/GLPI/plugins/datainjection/inc/commoninjectionlib.class.php at line 1518
  Backtrace :
  ...injection/inc/commoninjectionlib.class.php:1453 PluginDatainjectionCommonInjectionLib->effectiveAddOrUpdate()
  ...s/datainjection/inc/phoneinjection.class.php:87 PluginDatainjectionCommonInjectionLib->processAddOrUpdate()
  plugins/datainjection/inc/engine.class.php:147     PluginDatainjectionPhoneInjection->addOrUpdateObject()
  ...datainjection/inc/clientinjection.class.php:267 PluginDatainjectionEngine->injectLine()
  ...datainjection/inc/clientinjection.class.php:219 PluginDatainjectionClientInjection::processInjection()
  ...datainjection/front/clientinjection.form.php:40 PluginDatainjectionClientInjection::showInjectionForm()
```

The fix is added oustside previous ```if```

https://github.com/stonebuzz/datainjection/blob/ed0ae877c4fbde974bd3464eb295a5589742096d/inc/commoninjectionlib.class.php#L1515-L1523

