### PR TITLE
fix(datainjection): restore fields implementation

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1525,6 +1525,12 @@ class PluginDatainjectionCommonInjectionLib
          if ($key === 'entities_id') {
             $toinject[$key] = $value;
          }
+
+         //useful for fields
+         if (strpos(get_class($item), 'PluginFields') !== false &&
+           ($key === 'items_id' || $key === 'itemtype')) {
+            $toinject[$key] = $value;
+         }
       }
 
       $toinject = Toolbox::addslashes_deep($toinject);

--- a/inc/engine.class.php
+++ b/inc/engine.class.php
@@ -192,7 +192,7 @@ class PluginDatainjectionEngine
       );
       $return_value = $value;
 
-      if (($option['displaytype'] == 'multiline_text')
+      if ($option !== false && ($option['displaytype'] == 'multiline_text')
           && in_array($mapping->getValue(), $several)
           && ($value != PluginDatainjectionCommonInjectionLib::EMPTY_VALUE)
       ) {


### PR DESCRIPTION
Try to repair "fields implementation"

Preserve ```itemtype``` and ```items_id``` when injected class is from ```fields``` plugin 