### PR TITLE
fix(injection): fix DBRelation injection

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1534,8 +1534,7 @@ class PluginDatainjectionCommonInjectionLib
 
          if (
             in_array(get_class($item), [
-               Infocom::getType(),
-               Item_OperatingSystem::getType()
+               Infocom::getType()
             ])
             && in_array($key, [
                'items_id',
@@ -1543,6 +1542,17 @@ class PluginDatainjectionCommonInjectionLib
             ])
          ) {
             $toinject[$key] = $value;
+         }
+
+         if (
+            $item instanceof CommonDBRelation
+            && in_array($key, [
+               'items_id',
+               'itemtype',
+               $item::$items_id_1
+            ])
+         ) {
+               $toinject[$key] = $value;
          }
 
          //keep id in case of update

--- a/inc/contract_iteminjection.class.php
+++ b/inc/contract_iteminjection.class.php
@@ -48,7 +48,7 @@ class PluginDatainjectionContract_ItemInjection extends Contract_Item
 
    function relationSide() {
 
-      return false;
+      return true;
    }
 
 


### PR DESCRIPTION
fix DBRelation injection (retrieve missing field from relation)
change relation side from ```contract_iteminjection``` to prevent SQL error

```sql
[2022-06-08 19:19:39] glpisqllog.ERROR: DBmysql::query() in C:\laragon\www\glpi\inc\dbmysql.class.php line 335
*** MySQL query error:
SQL: SELECT *
FROM `glpi_contracts_items` WHERE 1 AND `contracts_id`='104' AND `Contract`='' AND `items_id`='33'
Error: Unknown column 'Contract' in 'where clause'
Backtrace :
...injection\inc\commoninjectionlib.class.php:1827
...injection\inc\commoninjectionlib.class.php:1476 PluginDatainjectionCommonInjectionLib->dataAlreadyInDB()
...tainjection\inc\computerinjection.class.php:101 PluginDatainjectionCommonInjectionLib->processAddOrUpdate()
plugins\datainjection\inc\engine.class.php:147 PluginDatainjectionComputerInjection->addOrUpdateObject()
...datainjection\inc\clientinjection.class.php:267 PluginDatainjectionEngine->injectLine()
```