### PR TITLE
Fix search user by email

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1793,9 +1793,14 @@ class PluginDatainjectionCommonInjectionLib
                if ($itemtype == $this->primary_type) {
                   foreach ($this->mandatory_fields[$itemtype] as $field => $is_mandatory) {
                      if ($is_mandatory) {
-                        $option = self::findSearchOption($searchOptions, $field);
-                        $where .= " AND `" . $field . "`='".
-                          $this->getValueByItemtypeAndName($itemtype, $field) . "'";
+                        if ($item instanceof User && $field == "useremails_id") {
+                           $email = addslashes($this->getValueByItemtypeAndName($itemtype, $field));
+                           $where .= " AND `id` IN (SELECT `users_id` FROM glpi_useremails WHERE `email` = '$email') ";
+                        } else {
+                           $where .= " AND `" . $field . "`='".
+                              $this->getValueByItemtypeAndName($itemtype, $field) . "'";
+                        }
+
                      }
                   }
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1794,7 +1794,7 @@ class PluginDatainjectionCommonInjectionLib
                   foreach ($this->mandatory_fields[$itemtype] as $field => $is_mandatory) {
                      if ($is_mandatory) {
                         if ($item instanceof User && $field == "useremails_id") {
-                           $email = addslashes($this->getValueByItemtypeAndName($itemtype, $field));
+                           $email = $DB->escape($this->getValueByItemtypeAndName($itemtype, $field));
                            $where .= " AND `id` IN (SELECT `users_id` FROM glpi_useremails WHERE `email` = '$email') ";
                         } else {
                            $where .= " AND `" . $field . "`='".


### PR DESCRIPTION
Using this simple CSV file containing users login and emails (imagine real emails instead of **** 😅):

![image](https://user-images.githubusercontent.com/42734840/173044718-a918a4e8-7fb6-4279-8081-8d7a12787fe6.png)

The goal is, for each row, to find the user with the matching email and update its login.

Here is the model we are using:

![image](https://user-images.githubusercontent.com/42734840/173044972-c9658cb8-7194-4d9a-a81c-8ddb67c4560c.png)

The import will fail because datainjection doesn't seem to handle users search by email very well:

![image](https://user-images.githubusercontent.com/42734840/173045209-ec0d34cd-2135-4530-b91f-5177d447a034.png)

The query has no chance to succeed as it is looking for a foreign key that doesn't exist (and with an incorrect value - the raw email wouldn't be a valid foreign key anyway):
```sql
SELECT * FROM `glpi_users` WHERE 1 AND `is_deleted` = '0' AND `useremails_id`='*****@*****'
```

The correct query would be:

```sql
SELECT * FROM `glpi_users` WHERE 1 AND `is_deleted` = '0' AND `id` IN (
    SELECT `user_id` FROM glpi_useremails WHERE `email` = '*****@*****'
);
```

To fix this, I've added a specific check for this special case of searching users by email.

Internal ref: !24192