### PR TITLE
ITILCategories: fix set parent category

### DIFF
--- a/inc/itilcategoryinjection.class.php
+++ b/inc/itilcategoryinjection.class.php
@@ -69,7 +69,7 @@ class PluginDatainjectionITILCategoryInjection extends ITILCategory
 
       $options['ignore_fields'] = array_merge($blacklist, $notimportable);
 
-      $options['displaytype'] = ["dropdown"       => [71, 72, 73],
+      $options['displaytype'] = ["dropdown"       => [13, 71, 72, 73],
                                     "bool"           => [3, 74, 75, 76, 86],
                                     "user"           => [70],
                                     "multiline_text" => [16]];


### PR DESCRIPTION
CSV file:

![image](https://user-images.githubusercontent.com/42734840/173328083-ac0e0a14-9039-459d-823d-26a430d9ec59.png)

The goal is to find a category using its completename and update its parent category.

Model:

![image](https://user-images.githubusercontent.com/42734840/173328320-ccfb1d89-ddc5-47fb-8a45-d145f823ff4a.png)

The import does not work (parent category is set to null):

![image](https://user-images.githubusercontent.com/42734840/173328607-53988ca2-d33c-41c7-bff7-0acd4f0384a8.png)

It seems like the "Father" search option is not declared as a dropdown.
After adding the searchoption's id (13) to the dropdown list, the import work as expected:

![image](https://user-images.githubusercontent.com/42734840/173328658-9f1e65fe-5755-434f-ab60-181491a412c6.png)
