### PR TITLE
move item order from array if needed

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1466,11 +1466,11 @@ class PluginDatainjectionCommonInjectionLib
 
                //Process other types
 
-               //change order of item if needed
+               //change order of items if needed
                if(isset($this->values['NetworkPort']) && isset($this->values['NetworkName'])){
                   $np = $this->values['NetworkPort'];
                   unset($this->values['NetworkPort']);
-                  array_unshift($this->values, $np);
+                  $this->values = array('NetworkPort' => $np) + $this->values;
                }
 
                foreach ($this->values as $itemtype => $data) {

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1465,6 +1465,14 @@ class PluginDatainjectionCommonInjectionLib
                $this->results[get_class($item)] = $newID;
 
                //Process other types
+
+               //change order of item if needed
+               if(isset($this->values['NetworkPort']) && isset($this->values['NetworkName'])){
+                  $np = $this->values['NetworkPort'];
+                  unset($this->values['NetworkPort']);
+                  array_unshift($this->values, $np);
+               }
+
                foreach ($this->values as $itemtype => $data) {
                   //Do not process primary_type
 


### PR DESCRIPTION
The injection process is based on the order of the columns in the CSV file
Which can be annoying in some cases
We need to move item before another

Ex : NetworkPort before NetworkName

it's ugly ! we agree, but I have no other solution for the moment