### PR TITLE
Fix group user import

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1521,13 +1521,14 @@ class PluginDatainjectionCommonInjectionLib
 
       foreach ($values as $key => $value) {
          $option = self::findSearchOption($options, $key);
-         if ($key === 'id' || $option !== false && (!isset($option['checktype']) || $option['checktype'] != self::FIELD_VIRTUAL)) {
-            //If field is a dropdown and value is '', then replace it by 0
-            if ($option !== false && self::isFieldADropdown($option['displaytype']) && $value == self::EMPTY_VALUE) {
-               $toinject[$key] = self::DROPDOWN_EMPTY_VALUE;
-            } else {
-               $toinject[$key] = $value;
-            }
+         if ($option === false) {
+             $toinject[$key] = $value;
+         } else if (!isset($option['checktype']) || $option['checktype'] != self::FIELD_VIRTUAL) {
+             if (self::isFieldADropdown($option['displaytype']) && $value == self::EMPTY_VALUE) {
+                 $toinject[$key] = self::DROPDOWN_EMPTY_VALUE;
+             } else {
+                 $toinject[$key] = $value;
+             }
          }
 
          if ($key === 'entities_id') {

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1531,42 +1531,6 @@ class PluginDatainjectionCommonInjectionLib
          } else {
              $toinject[$key] = $value;
          }
-
-         if ($key === 'entities_id') {
-            $toinject[$key] = $value;
-         }
-
-         //useful for fields
-         if (strpos(get_class($item), 'PluginFields') !== false &&
-           ($key === 'items_id' || $key === 'itemtype')) {
-            $toinject[$key] = $value;
-         }
-
-         if (
-            $item instanceof CommonDBChild
-            && in_array($key, [
-               'items_id',
-               'itemtype'
-            ])
-         ) {
-            $toinject[$key] = $value;
-         }
-
-         if (
-            $item instanceof CommonDBRelation
-            && in_array($key, [
-               'items_id',
-               'itemtype',
-               $item::$items_id_1
-            ])
-         ) {
-               $toinject[$key] = $value;
-         }
-
-         //keep id in case of update
-         if (!$add && $key === 'id') {
-            $toinject[$key] = $value;
-         }
       }
 
       $toinject = Toolbox::addslashes_deep($toinject);

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1521,14 +1521,15 @@ class PluginDatainjectionCommonInjectionLib
 
       foreach ($values as $key => $value) {
          $option = self::findSearchOption($options, $key);
-         if ($option === false) {
+         if ($option !== false && isset($option['checktype']) && $option['checktype'] == self::FIELD_VIRTUAL) {
+             break;
+         }
+
+         if ($option !== false && self::isFieldADropdown($option['displaytype']) && $value == self::EMPTY_VALUE) {
+             //If field is a dropdown and value is '', then replace it by 0
+             $toinject[$key] = self::DROPDOWN_EMPTY_VALUE;
+         } else {
              $toinject[$key] = $value;
-         } else if (!isset($option['checktype']) || $option['checktype'] != self::FIELD_VIRTUAL) {
-             if (self::isFieldADropdown($option['displaytype']) && $value == self::EMPTY_VALUE) {
-                 $toinject[$key] = self::DROPDOWN_EMPTY_VALUE;
-             } else {
-                 $toinject[$key] = $value;
-             }
          }
 
          if ($key === 'entities_id') {


### PR DESCRIPTION
Try to fix certain cases of imports such as a Group import that includes a group member field.
Commit 69748585a43a5d73aa4a0a061d0e519b97b943ed had broken this type of import because `effectiveAddOrUpdate` would receive an `itemtype` and `items_id` value which were not valid search options, but were still required for the import to work.

This patch seems to resolve this particular issue although I don't know if it will cause other issues.