### PR TITLE
fix(import): carriage return

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
+
 class PluginDatainjectionCommonInjectionLib
 {
 
@@ -1369,6 +1371,7 @@ class PluginDatainjectionCommonInjectionLib
       $add      = true;
       $accepted = false;
 
+      $this->values = Sanitizer::dbUnescapeRecursive($this->values);
       //Toolbox::logDebug("processAddOrUpdate(), start with", $this->values);
 
       // Initial value, will be change when problem
@@ -1559,6 +1562,8 @@ class PluginDatainjectionCommonInjectionLib
             $toinject[$key] = $value;
          }
       }
+
+      $toinject = Sanitizer::dbEscapeRecursive($toinject);
 
       $newID = null;
       if (method_exists($injectionClass, 'customimport')) {

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1369,7 +1369,6 @@ class PluginDatainjectionCommonInjectionLib
       $add      = true;
       $accepted = false;
 
-      $this->values = Toolbox::stripslashes_deep($this->values);
       //Toolbox::logDebug("processAddOrUpdate(), start with", $this->values);
 
       // Initial value, will be change when problem
@@ -1560,8 +1559,6 @@ class PluginDatainjectionCommonInjectionLib
             $toinject[$key] = $value;
          }
       }
-
-      $toinject = Toolbox::addslashes_deep($toinject);
 
       $newID = null;
       if (method_exists($injectionClass, 'customimport')) {


### PR DESCRIPTION
Line breaks in a multiline field (e.g. comment) were lost and replaced by `n` or `rn`:

![image](https://user-images.githubusercontent.com/8530352/189128305-f41f3184-f8b8-485d-9322-3a353a64f496.png)

Internal reference : !24858