### PR TITLE
fix(injection): declare searchoption as dropdown type

### DIFF
--- a/inc/tasktemplateinjection.class.php
+++ b/inc/tasktemplateinjection.class.php
@@ -70,6 +70,7 @@ class PluginDatainjectionTaskTemplateInjection extends TaskTemplate
       $options['ignore_fields'] = array_merge($blacklist, $notimportable);
 
       $options['displaytype']   = ["bool"           => [86],
+                                      "dropdown" => [3],
                                       "multiline_text" => [4, 16]];
 
       return PluginDatainjectionCommonInjectionLib::addToSearchOptions($tab, $options, $this);


### PR DESCRIPTION
Fix ```searchoption``` not declared as ```dropdown``` 
like ```https://github.com/pluginsGLPI/datainjection/pull/323/commits/df6809d689978ace00da29d0e294ee09035b748e```

Prevent SQL error 

```sql
Incorrect integer value: 'Internet' for column `10bugfixes`.`glpi_tasktemplates`.`taskcategories_id` at row 1
```

++