### PR TITLE
Fix import of appliances groups

### DIFF
--- a/inc/applianceinjection.class.php
+++ b/inc/applianceinjection.class.php
@@ -63,7 +63,7 @@ class PluginDatainjectionApplianceInjection extends Appliance
       $options['ignore_fields'] = array_merge($blacklist, $notimportable);
       $options['displaytype']   = [
                "multiline_text" => [4],
-               "dropdown"       => [10, 11, 32],
+               "dropdown"       => [8, 10, 11, 32, 49],
                "user"           => [6, 24],
                "bool"           => [7, 61]
       ];


### PR DESCRIPTION
Add `Group` and `Group in charge` search options to the dropdown list for Appliances.

With this fix, they will be able to be imported by their names instead of using raw databases ids.