### PR TITLE
Statecheck Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ dist/
 vendor/
 .gh_token
 *.min.*
-
+.idea

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Data to be imported using the plugins are:
 - management data (contract, contact, supplier),
 - configuration data (user, group, entity).
 
+## Plugins Integrations
+*>= 2.13.4*: **Statecheck @2.4.0** - From these versions, if Statecheck is installed and activated, Data Injection invokes its hook to check defined rules for each CSV entry;
+The resulting CSV contains the last column with all the rules fired but not respected.
+
 ## Documentation
 
 We maintain a detailed documentation here -> [Documentation](https://glpi-plugins.readthedocs.io/en/latest/datainjection/index.html)

--- a/datainjection.xml
+++ b/datainjection.xml
@@ -28,6 +28,11 @@
       <author>Xavier Caillaud</author>
    </authors>
    <versions>
+       <version>
+           <num>2.13.4</num>
+           <compatibility>~10.0.0</compatibility>
+           <download_url>https://github.com/pluginsGLPI/datainjection/releases/download/2.13.4/glpi-datainjection-2.13.4.tar.bz2</download_url>
+       </version>
       <version>
           <num>2.13.3</num>
           <compatibility>~10.0.0</compatibility>

--- a/inc/engine.class.php
+++ b/inc/engine.class.php
@@ -149,6 +149,10 @@ class PluginDatainjectionEngine
       //Add injected line number to the result array
       $results['line'] = $index;
       if ($results['status'] != PluginDatainjectionCommonInjectionLib::SUCCESS) {
+          $errorMessage = $results['hookerrormessage'];
+          if (isset($errorMessage)) {
+            array_push($line, $errorMessage);
+          }
           $this->error_lines[] = $line;
       }
        return $results;

--- a/setup.php
+++ b/setup.php
@@ -28,12 +28,15 @@
  * -------------------------------------------------------------------------
  */
 
-define ('PLUGIN_DATAINJECTION_VERSION', '2.13.3');
+define ('PLUGIN_DATAINJECTION_VERSION', '2.13.4');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_DATAINJECTION_MIN_GLPI", "10.0.0");
 // Maximum GLPI version, exclusive
 define("PLUGIN_DATAINJECTION_MAX_GLPI", "10.0.99");
+
+// Minimal STATECHECK Plugin version, inclusive
+define("PLUGIN_DATAINJECTION_MIN_STATECHECK", "2.4.0");
 
 if (!defined("PLUGIN_DATAINJECTION_UPLOAD_DIR")) {
     define("PLUGIN_DATAINJECTION_UPLOAD_DIR", GLPI_PLUGIN_DOC_DIR."/datainjection/");


### PR DESCRIPTION
Data Injection Plugin will be able to integrate itself with Statecheck Plugin.
For each CSV entry, rules defined with Statecheck Plugin will be triggered. All the entries not respecting these rules will be discarded. The resulting CSV will contain the note on which rules have been fired but not respected.