### PR TITLE
fix(Item_Operatingsystem): update / handle one OS like GLPI

### DIFF
--- a/inc/item_operatingsysteminjection.class.php
+++ b/inc/item_operatingsysteminjection.class.php
@@ -94,9 +94,9 @@ class PluginDatainjectionItem_OperatingsystemInjection extends Item_OperatingSys
 
 
    /**
-    * @param $injectionClass
-    * @param $values
-    * @param $options
+    * @param PluginDatainjectionInjectionInterface $injectionClass
+    * @param array $values
+    * @param array $options
    **/
   function customDataAlreadyInDB($injectionClass, $values, $options) {
       $item_operatingsystem = new Item_OperatingSystem();

--- a/inc/item_operatingsysteminjection.class.php
+++ b/inc/item_operatingsysteminjection.class.php
@@ -92,6 +92,25 @@ class PluginDatainjectionItem_OperatingsystemInjection extends Item_OperatingSys
       return $lib->getInjectionResults();
    }
 
+
+   /**
+    * @param $injectionClass
+    * @param $values
+    * @param $options
+   **/
+  function customDataAlreadyInDB($injectionClass, $values, $options) {
+      $item_operatingsystem = new Item_OperatingSystem();
+      if (!$item_operatingsystem->getFromDBByCrit([
+         'itemtype' => $values['itemtype'],
+         'items_id' => $values['items_id'],
+      ])) {
+         return false;
+      } else {
+         return $item_operatingsystem->getID();
+      }
+   }
+
+
    /**
     * @param $primary_type
     * @param $values

--- a/inc/item_operatingsysteminjection.class.php
+++ b/inc/item_operatingsysteminjection.class.php
@@ -99,14 +99,21 @@ class PluginDatainjectionItem_OperatingsystemInjection extends Item_OperatingSys
     * @param array $options
    **/
   function customDataAlreadyInDB($injectionClass, $values, $options) {
-      $item_operatingsystem = new Item_OperatingSystem();
-      if (!$item_operatingsystem->getFromDBByCrit([
-         'itemtype' => $values['itemtype'],
-         'items_id' => $values['items_id'],
-      ])) {
-         return false;
+      global $DB;
+      $item_operatingsystem = new \Item_OperatingSystem();
+      $matching_os = $DB->request([
+         'FROM' => $item_operatingsystem->getTable(),
+         'WHERE' => [
+            'itemtype' => $values['itemtype'],
+            'items_id' => $values['items_id'],
+         ],
+         'LIMIT' => 1, // Get the first item_OS
+      ]);
+      if ($matching_os->count() > 0) {
+         $item_operatingsystem->getFromResultSet($matching_os->current());
+         return $item_operatingsystem->fields['id'];
       } else {
-         return $item_operatingsystem->getID();
+         return false;
       }
    }
 


### PR DESCRIPTION
When importing computers with DataInjection, the operating system is added, not replaced. This results in 2 or more OS per computer, which should even not be possible in GLPI.

This PR fix this

fix : internal ref : 30448