### PR TITLE
fix(injection): allow lockedfield update

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1552,6 +1552,8 @@ class PluginDatainjectionCommonInjectionLib
                self::logAddOrUpdate($item, $add);
             }
          } else {
+            // allow to update locked fields from datainjection
+            // for dynamic item if needed
             if ($item->maybeDynamic()) {
                $toinject['is_dynamic'] = 0;
             }

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1552,6 +1552,9 @@ class PluginDatainjectionCommonInjectionLib
                self::logAddOrUpdate($item, $add);
             }
          } else {
+            if ($item->maybeDynamic()) {
+               $toinject['is_dynamic'] = 0;
+            }
             if ($item->update($toinject)) {
                $newID = $toinject['id'];
                self::logAddOrUpdate($item, $add);


### PR DESCRIPTION
When an object is dynamic and a field is locked (manually updated)

Datainjection cannot also update this field

This PR fix this

#342 
