### PR TITLE
Drop old debug configs

### DIFF
--- a/inc/clientinjection.class.php
+++ b/inc/clientinjection.class.php
@@ -232,7 +232,7 @@ class PluginDatainjectionClientInjection
       ini_set("max_execution_time", "0");
 
       // Disable recording each SQL request in $_SESSION
-      $CFG_GLPI["debug_sql"] = 0;
+      \Glpi\Debug\Profile::getCurrent()->disable();
 
       $nblines         = PluginDatainjectionSession::getParam('nblines');
       $clientinjection = new PluginDatainjectionClientInjection;
@@ -300,7 +300,7 @@ class PluginDatainjectionClientInjection
          );
 
          // Restore
-         $CFG_GLPI["debug_sql"] = 1;
+         \Glpi\Debug\Profile::getCurrent()->enable();
 
          //Close CSV file
          $backend->closeFile();


### PR DESCRIPTION
These had no effect since the addition of the debug bar in GLPI 10.0.8. glpi-project/glpi#16448 (for GLPI 10.1) adds some methods to pause/resume the collection of new debug data as a replacement.