### PR TITLE
fix(Model): fix model visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix visibility of injection models
+
 
 ## [2.13.5] - 2024-02-22
 

--- a/hook.php
+++ b/hook.php
@@ -1986,9 +1986,9 @@ function plugin_datainjection_addDefaultWhere($itemtype)
                 foreach ($models as $model) {
                     $tab[] = $model['id'];
                 }
-                if (count($tab) > 0) {
-                    return "`glpi_plugin_datainjection_models`.`id` IN ('" . implode("','", $tab) . "')";
-                }
+                return "`glpi_plugin_datainjection_models`.`id` IN ('" . implode("','", $tab) . "')";
+            } else {
+                return "1 = 0"; //no model available -> force WHERE clause to get no result
             }
             return false;
         default:


### PR DESCRIPTION
When the user does not have a model (```private``` or ```public```), the plugin loads all models.

This PR fixes this problem by adding a where clause that will force a query to return no results (fake comparison)

Fix https://github.com/pluginsGLPI/datainjection/issues/352