### PR TITLE
Fix port unicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix network port unicity
 - Fix visibility of injection models
 - Fix ```CommonDBRelation``` import
 

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -746,6 +746,14 @@ class PluginDatainjectionModel extends CommonDBTM
         );
         echo "</td></tr>";
 
+        echo "<td>" . __('Port unicity criteria', 'datainjection') . "</td>";
+        echo "<td>";
+        Dropdown::showFromArray(
+            'port_unicity',
+            PluginDatainjectionDropdown::portUnicityValues(),
+            ['value' => $this->fields['port_unicity']]
+        );
+        echo "</td></tr>";
         if ($ID > 0) {
             $tmp = self::getInstance('csv');
             $tmp->showAdditionnalForm($this);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !34299

After some discussion, it was removed because he thought that the port uniqueness option depended on ‘perform_network_connection’ (which was an unused option) when it didn't