### PR TITLE
Fix(Injection): prevent Agent deletion on update dynamic object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix visibility of injection models
 - Fix ```CommonDBRelation``` import
 - Fix ```IPAddress``` import which adds a ```lock``` on ```last_update``` field
-
+- Fix ```Agent``` lost when update dynamic asset
 
 ## [2.13.5] - 2024-02-22
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1656,7 +1656,7 @@ class PluginDatainjectionCommonInjectionLib
                // allow to update locked fields from datainjection
                // for dynamic item if needed
                 if ($item->maybeDynamic()) {
-                    $toinject['is_dynamic'] = 0;
+                    unset($toinject['is_dynamic']);
                 }
                 if ($item->update($toinject)) {
                     $newID = $toinject['id'];


### PR DESCRIPTION
When a dynamic `asset` is update by plugin

link with agent is lost (`Agent` is not deleted, it's the `asset` that's no longer dynamic ```is_dynamic = 0```)

Fix #413 