### PR TITLE
Fix(Injection): prevent locked date_mod field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix network port unicity
 - Fix visibility of injection models
 - Fix ```CommonDBRelation``` import
+- Fix ```IPAddress``` import which adds a ```lock``` on ```last_update``` field
+
 
 ## [2.13.5] - 2024-02-22
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1540,9 +1540,14 @@ class PluginDatainjectionCommonInjectionLib
 
                   //change order of items if needed
                     if (isset($this->values['NetworkPort']) && isset($this->values['NetworkName'])) {
-                        $np = $this->values['NetworkPort'];
+                        $nw = $this->values['NetworkPort'];
                         unset($this->values['NetworkPort']);
-                        $this->values = array('NetworkPort' => $np) + $this->values;
+                        $networkNameIndex = array_search('NetworkName', array_keys($this->values));
+                        $this->values = array_merge(
+                            array_slice($this->values, 0, $networkNameIndex),
+                            array('NetworkPort' => $nw),
+                            array_slice($this->values, $networkNameIndex)
+                        );
                     }
 
                     foreach ($this->values as $itemtype => $data) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since https://github.com/pluginsGLPI/datainjection/pull/303

`IPAddress` injection no longer work and adds lock for `date_mod` fields

The reordering of the `array` is a bit violent (put `NetworkPort` at the beginning).

Here's a better solution (put `NetworkPort` just before `NetworkName`) because to manage the `IPAddress`, the `NetworkPort` must be managed beforehand

fix !34426

## Screenshots (if appropriate):

