### PR TITLE
fix: deprecated function utf8_encode

### DIFF
--- a/inc/backend.class.php
+++ b/inc/backend.class.php
@@ -105,7 +105,7 @@ abstract class PluginDatainjectionBackend
     {
 
         if (!self::is_utf8($string)) {
-            return utf8_encode($string);
+            return Toolbox::encodeInUtf8($string);
         }
         return $string;
     }

--- a/inc/backendcsv.class.php
+++ b/inc/backendcsv.class.php
@@ -104,7 +104,7 @@ class PluginDatainjectionBackendcsv extends PluginDatainjectionBackend implement
                   //If file is ISO8859-1 : encode the data in utf8
                     case PluginDatainjectionBackend::ENCODING_ISO8859_1:
                         if (!Toolbox::seems_utf8($tmp)) {
-                            $csv[0][] = utf8_encode($tmp);
+                            $csv[0][] = Toolbox::encodeInUtf8($tmp);
                         } else {
                             $csv[0][] = $tmp;
                         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

```
glpiphplog.NOTICE:   *** PHP Deprecated function (8192): Function utf8_encode() is deprecated in /home/ubuntu/Dev/GLPI/10.0-bugfixes/plugins/datainjection/inc/backend.class.php at line 108
  Backtrace :
  plugins/datainjection/inc/backendcsv.class.php:118 PluginDatainjectionBackend::toUTF8()
  plugins/datainjection/inc/backendcsv.class.php:247 PluginDatainjectionBackendcsv::parseLine()
  ...datainjection/inc/clientinjection.class.php:299 PluginDatainjectionBackendcsv->getNextLine()
  ...datainjection/inc/clientinjection.class.php:226 PluginDatainjectionClientInjection::processInjection()
  ...datainjection/front/clientinjection.form.php:45 PluginDatainjectionClientInjection::showInjectionForm()
  public/index.php:82                                require()
```

## Screenshots (if appropriate):

