### PR TITLE
Fix for issue #371

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix default entity insertion for a user
-- Fixed the SQL error on creating new injection model
+- Fixed `SQL` error when creating new injection model
 
 ## [2.14.0] - 2024-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix default entity insertion for a user
+- Fixed the SQL error on creating new injection model
 
 ## [2.14.0] - 2024-10-10
 

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -1340,33 +1340,30 @@ class PluginDatainjectionModel extends CommonDBTM
         /** @var DBmysql $DB */
         global $DB;
 
-        $model = new self();
-        $model->getFromDB($models_id);
-
         $continue = true;
 
-        if(empty($models_id)){
-            $models_id = '-1';
-        }
+        $model = new self();
+        
+        if($model->getFromDB($models_id)){      
+            $query = "(SELECT `itemtype`
+                    FROM `glpi_plugin_datainjection_models`
+                    WHERE `id` = '" . $models_id . "')
+                    UNION (SELECT DISTINCT `itemtype`
+                        FROM `glpi_plugin_datainjection_mappings`
+                        WHERE `models_id` = '" . $models_id . "')
+                    UNION (SELECT DISTINCT `itemtype`
+                        FROM `glpi_plugin_datainjection_infos`
+                        WHERE `models_id` = '" . $models_id . "')";
+            foreach ($DB->request($query) as $data) {
+                if ($data['itemtype'] != PluginDatainjectionInjectionType::NO_VALUE) {
+                    if (class_exists($data['itemtype'])) {
+                        $item                     = new $data['itemtype']();
+                        $item->fields['itemtype'] = $model->fields['itemtype'];
 
-        $query = "(SELECT `itemtype`
-                 FROM `glpi_plugin_datainjection_models`
-                 WHERE `id` = '" . $models_id . "')
-                UNION (SELECT DISTINCT `itemtype`
-                       FROM `glpi_plugin_datainjection_mappings`
-                       WHERE `models_id` = '" . $models_id . "')
-                UNION (SELECT DISTINCT `itemtype`
-                       FROM `glpi_plugin_datainjection_infos`
-                       WHERE `models_id` = '" . $models_id . "')";
-        foreach ($DB->request($query) as $data) {
-            if ($data['itemtype'] != PluginDatainjectionInjectionType::NO_VALUE) {
-                if (class_exists($data['itemtype'])) {
-                    $item                     = new $data['itemtype']();
-                    $item->fields['itemtype'] = $model->fields['itemtype'];
-
-                    if (!($item instanceof CommonDBRelation) && !$item->canCreate()) {
-                        $continue = false;
-                        break;
+                        if (!($item instanceof CommonDBRelation) && !$item->canCreate()) {
+                            $continue = false;
+                            break;
+                        }
                     }
                 }
             }

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -1345,6 +1345,10 @@ class PluginDatainjectionModel extends CommonDBTM
 
         $continue = true;
 
+        if(empty($models_id)){
+            $models_id = '-1';
+        }
+
         $query = "(SELECT `itemtype`
                  FROM `glpi_plugin_datainjection_models`
                  WHERE `id` = '" . $models_id . "')

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -1343,8 +1343,7 @@ class PluginDatainjectionModel extends CommonDBTM
         $continue = true;
 
         $model = new self();
-        
-        if($model->getFromDB($models_id)){      
+        if ($model->getFromDB($models_id)) {
             $query = "(SELECT `itemtype`
                     FROM `glpi_plugin_datainjection_models`
                     WHERE `id` = '" . $models_id . "')


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #371 
- Here is a brief description of what this PR does: When loading the form to add a new injection model the DB is queried multiple times by the checkRightOnModel() function with  `""` as the `$models_id` (since no model is being selected).  This throws multiple errors of

```
SQL Warnings: 1292: Truncated incorrect DECIMAL value: '' in query "(SELECT `itemtype` FROM `glpi_plugin_datainjection_models` WHERE `id` = '') UNION (SELECT DISTINCT `itemtype` FROM `glpi_plugin_datainjection_mappings` WHERE `models_id` = '') UNION (SELECT DISTINCT `itemtype` FROM `glpi_plugin_datainjection_infos` WHERE `models_id` = '')"
```

This change sets it to `-1` when null in order to feed a valid value into the query. 

I've confirmed that existing models still load without issue, and the error for a new model no longer appears.

## Screenshots (if appropriate):

