### PR TITLE
Fix for Missing Dropdown Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix default entity insertion for a user
 - Fixed `SQL` error when creating new injection model
+- Fixed issue with missing dropdown options
 
 ## [2.14.0] - 2024-10-10
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -2175,6 +2175,13 @@ class PluginDatainjectionCommonInjectionLib
                         $type_searchOptions[$id]['injectable'] = self::FIELD_INJECTABLE;
                     }
 
+                    //Some injection.class files are missing dropdown options. Set displaytype as dropdown if datatype is dropdown
+                    //$tmp['displaytype'] is still empty. Set to prevent overwriting on next IF
+                    if (isset($tmp['datatype']) && $tmp['datatype'] == 'dropdown') {
+                        $type_searchOptions[$id]['displaytype'] = 'dropdown';
+                        $tmp['displaytype'] = 'dropdown';
+                    }
+
                     if (isset($tmp['linkfield']) && !isset($tmp['displaytype'])) {
                         $type_searchOptions[$id]['displaytype'] = 'text';
                     }

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -2177,7 +2177,7 @@ class PluginDatainjectionCommonInjectionLib
 
                     //Some injection.class files are missing dropdown options. Set displaytype as dropdown if datatype is dropdown
                     //$tmp['displaytype'] is still empty. Set to prevent overwriting on next IF
-                    if (isset($tmp['datatype']) && $tmp['datatype'] == 'dropdown') {
+                    if ((isset($tmp['datatype']) && $tmp['datatype'] == 'dropdown') && !isset($tmp['displaytype'])) {
                         $type_searchOptions[$id]['displaytype'] = 'dropdown';
                         $tmp['displaytype'] = 'dropdown';
                     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
I encountered an issue when trying to import software licenses where most dropdown fields were attempting to inject the text value in the import file rather than the foreign ID from the corresponding table. This was traced back to there being missing dropdown IDs in `softwarelicenseinjection.class.php`, Adding the missing IDs fixed this for injecting software licenses, however, there was no way to know if there were missing items in other classes.

I saw these options in the injection class were being used to set the `displaytype` of dropdown, which is later used to determine if a foreign table relation needed to be made. Rather than adding these manually, I've made a change to set the `displaytype` of `dropdown` from the rawSearchOptions that are being stored in `$tmp`.

After making this change and reverting to the original array set in `softwarelicenseinjection.class.php` ` $options['displaytype']   = ["dropdown"       => [5, 6, 7, 110],` I confirmed that I could now successfully inject software licenses.

- It fixes #444 
- Sets the `displaytype` from the rawSearchOptions in adition to the options manually entered array of options in the injection classes

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/f532b4de-6cf6-4b3e-9d8a-d1c767811a90)


