### PR TITLE
Fix: Replace multiline_text fields when prefixed with #replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `global`  configuration for injection links
 - Escape  data when check if already exist
 
+## [2.15.0] - 2025-02-26
+
+### Added
+
+- Add option to replace the value of multiline text fields
+
 ## [2.14.1] - 2024-12-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `global`  configuration for injection links
 - Escape  data when check if already exist
 
-## [2.15.0] - 2025-02-26
+## [Unreleased]
 
 ### Added
 
-- Add option to replace the value of multiline text fields
+- Add option to `replace` (instead of `append`)  the value of multiline text fields (e.g. `comment`)
 
 ## [2.14.1] - 2024-12-27
 

--- a/hook.php
+++ b/hook.php
@@ -240,10 +240,10 @@ function plugin_datainjection_migration_2141_2150(Migration $migration)
 {
     $migration->setVersion('2.15.0');
 
-    $migration->addPostQuery(
-        "ALTER TABLE `glpi_plugin_datainjection_models`
-         ADD `multiline_value_replace` tinyint NOT NULL DEFAULT '0'",
-        'Adding multiline_value_replace field to models'
+    $migration->addField(
+        'glpi_plugin_datainjection_models',
+        'multiline_value_replace',
+        'bool'
     );
 
     $migration->executeMigration();    

--- a/hook.php
+++ b/hook.php
@@ -67,6 +67,7 @@ function plugin_datainjection_install()
             plugin_datainjection_migration_251_252($migration);
             plugin_datainjection_migration_264_270($migration);
             plugin_datainjection_migration_2121_2122($migration);
+            plugin_datainjection_migration_2141_2150($migration);
             break;
 
         case 0:
@@ -91,6 +92,7 @@ function plugin_datainjection_install()
                      `float_format` tinyint NOT NULL DEFAULT '0',
                      `port_unicity` tinyint NOT NULL DEFAULT '0',
                      `step` int NOT NULL DEFAULT '0',
+                     `multiline_value_replace` tinyint NOT NULL DEFAULT '0',
                      PRIMARY KEY  (`id`)
                    ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
             $DB->doQueryOrDie($query, $DB->error());
@@ -196,6 +198,7 @@ function plugin_datainjection_install()
             plugin_datainjection_migration_264_270($migration);
             plugin_datainjection_migration_290_2100($migration);
             plugin_datainjection_migration_2121_2122($migration);
+            plugin_datainjection_migration_2141_2150($migration);
             break;
 
         default:
@@ -231,6 +234,19 @@ function plugin_datainjection_uninstall()
 
     plugin_init_datainjection();
     return true;
+}
+
+function plugin_datainjection_migration_2141_2150(Migration $migration)
+{
+    $migration->setVersion('2.15.0');
+
+    $migration->addPostQuery(
+        "ALTER TABLE `glpi_plugin_datainjection_models`
+         ADD `multiline_value_replace` tinyint NOT NULL DEFAULT '0'",
+        'Adding multiline_value_replace field to models'
+    );
+
+    $migration->executeMigration();    
 }
 
 function plugin_datainjection_migration_2121_2122(Migration $migration)

--- a/hook.php
+++ b/hook.php
@@ -92,7 +92,7 @@ function plugin_datainjection_install()
                      `float_format` tinyint NOT NULL DEFAULT '0',
                      `port_unicity` tinyint NOT NULL DEFAULT '0',
                      `step` int NOT NULL DEFAULT '0',
-                     `multiline_value_replace` tinyint NOT NULL DEFAULT '0',
+                     `replace_multiline_value` tinyint NOT NULL DEFAULT '0',
                      PRIMARY KEY  (`id`)
                    ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
             $DB->doQueryOrDie($query, $DB->error());
@@ -242,7 +242,7 @@ function plugin_datainjection_migration_2141_2150(Migration $migration)
 
     $migration->addField(
         'glpi_plugin_datainjection_models',
-        'multiline_value_replace',
+        'replace_multiline_value',
         'bool'
     );
 

--- a/hook.php
+++ b/hook.php
@@ -246,7 +246,7 @@ function plugin_datainjection_migration_2141_2150(Migration $migration)
         'bool'
     );
 
-    $migration->executeMigration();    
+    $migration->executeMigration();
 }
 
 function plugin_datainjection_migration_2121_2122(Migration $migration)

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -943,10 +943,16 @@ class PluginDatainjectionCommonInjectionLib
             $option = self::findSearchOption($injectionClass->getOptions($itemtype), $field);
 
             if (isset($option['displaytype']) && $option['displaytype'] == 'multiline_text') {
-                if ($fromdb) {
-                    $this->values[$itemtype][$field] = $value . "\n" . $this->values[$itemtype][$field];
+                // If the new value starts with "#replace", the old value is replaced with the new value
+                if (str_starts_with($this->values[$itemtype][$field], '#replace')) {
+                    // The "#replace" tag is removed
+                    $this->values[$itemtype][$field] = trim(str_replace('#replace', '', $this->values[$itemtype][$field]));
                 } else {
-                    $this->values[$itemtype][$field] = $this->values[$itemtype][$field] . "\n" . $value;
+                    if ($fromdb) {
+                        $this->values[$itemtype][$field] = $value . "\n" . $this->values[$itemtype][$field];
+                    } else {
+                        $this->values[$itemtype][$field] = $this->values[$itemtype][$field] . "\n" . $value;
+                    }
                 }
             } else if (
                 ($fromdb && $value && !$this->rights['overwrite_notempty_fields'])

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -140,7 +140,7 @@ class PluginDatainjectionCommonInjectionLib
             'can_add'                   => false,
             'can_update'                => false,
             'can_delete'                => false,
-            'multiline_value_replace'   => false,
+            'replace_multiline_value'   => false,
         ];
 
        //Field format options
@@ -944,9 +944,9 @@ class PluginDatainjectionCommonInjectionLib
             $option = self::findSearchOption($injectionClass->getOptions($itemtype), $field);
 
             if (isset($option['displaytype']) && $option['displaytype'] == 'multiline_text') {
-                // If multiline_value_replace is true, the old value is replaced with the new value
+                // If replace_multiline_value is true, the old value is replaced with the new value
                 // else, the new value is added to the old value
-                if (!$this->rights['multiline_value_replace']) {
+                if (!$this->rights['replace_multiline_value']) {
                     if ($fromdb) {
                         $this->values[$itemtype][$field] = $value . "\n" . $this->values[$itemtype][$field];
                     } else {

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -139,7 +139,8 @@ class PluginDatainjectionCommonInjectionLib
             'overwrite_notempty_fields' => false,
             'can_add'                   => false,
             'can_update'                => false,
-            'can_delete'                => false
+            'can_delete'                => false,
+            'multiline_value_replace'   => false,
         ];
 
        //Field format options
@@ -943,11 +944,9 @@ class PluginDatainjectionCommonInjectionLib
             $option = self::findSearchOption($injectionClass->getOptions($itemtype), $field);
 
             if (isset($option['displaytype']) && $option['displaytype'] == 'multiline_text') {
-                // If the new value starts with "#replace", the old value is replaced with the new value
-                if (str_starts_with($this->values[$itemtype][$field], '#replace')) {
-                    // The "#replace" tag is removed
-                    $this->values[$itemtype][$field] = trim(str_replace('#replace', '', $this->values[$itemtype][$field]));
-                } else {
+                // If multiline_value_replace is true, the old value is replaced with the new value
+                // else, the new value is added to the old value
+                if (!$this->rights['multiline_value_replace']) {
                     if ($fromdb) {
                         $this->values[$itemtype][$field] = $value . "\n" . $this->values[$itemtype][$field];
                     } else {

--- a/inc/engine.class.php
+++ b/inc/engine.class.php
@@ -131,7 +131,7 @@ class PluginDatainjectionEngine
        //Rights options
         $rights = ['add_dropdown'              => $this->getModel()->getCanAddDropdown(),
             'overwrite_notempty_fields' => $this->getModel()->getCanOverwriteIfNotEmpty(),
-            'multiline_value_replace'   => $this->getModel()->getMultilineValueReplace(),
+            'replace_multiline_value'   => $this->getModel()->getReplaceMultilineValue(),
             'can_add'                   => $this->model->getBehaviorAdd(),
             'can_update'                => $this->model->getBehaviorUpdate(),
             'can_delete'                => false

--- a/inc/engine.class.php
+++ b/inc/engine.class.php
@@ -131,6 +131,7 @@ class PluginDatainjectionEngine
        //Rights options
         $rights = ['add_dropdown'              => $this->getModel()->getCanAddDropdown(),
             'overwrite_notempty_fields' => $this->getModel()->getCanOverwriteIfNotEmpty(),
+            'multiline_value_replace'   => $this->getModel()->getMultilineValueReplace(),
             'can_add'                   => $this->model->getBehaviorAdd(),
             'can_update'                => $this->model->getBehaviorUpdate(),
             'can_delete'                => false

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -251,6 +251,13 @@ class PluginDatainjectionModel extends CommonDBTM
         return $this->fields["port_unicity"];
     }
 
+    
+    public function getMultilineValueReplace()
+    {
+
+        return $this->fields["multiline_value_replace"];
+    }
+
 
     public function getNumberOfMappings()
     {
@@ -520,6 +527,14 @@ class PluginDatainjectionModel extends CommonDBTM
             'datatype'      => 'bool',
         ];
 
+        $tab[] = [
+            'id'            => 87,
+            'table'         => $this->getTable(),
+            'field'         => 'multiline_value_replace',
+            'name'          => __('Multiline field value replace', 'datainjection'),
+            'datatype'      => 'bool',
+        ];
+
         return $tab;
     }
 
@@ -753,6 +768,11 @@ class PluginDatainjectionModel extends CommonDBTM
             PluginDatainjectionDropdown::portUnicityValues(),
             ['value' => $this->fields['port_unicity']]
         );
+        echo "</td>";
+        echo "<td>" . __('Replacing the value of multiline text fields', 'datainjection') . "</td>";
+        echo "<td>";
+        Dropdown::showYesNo("multiline_value_replace", $this->fields['multiline_value_replace']);
+        echo "</td>";
         echo "</td></tr>";
         if ($ID > 0) {
             $tmp = self::getInstance('csv');

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -531,7 +531,7 @@ class PluginDatainjectionModel extends CommonDBTM
             'id'            => 87,
             'table'         => $this->getTable(),
             'field'         => 'multiline_value_replace',
-            'name'          => __('Multiline field value replace', 'datainjection'),
+            'name'          => __('Replacing the value of multiline text fields', 'datainjection'),
             'datatype'      => 'bool',
         ];
 

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -251,7 +251,7 @@ class PluginDatainjectionModel extends CommonDBTM
         return $this->fields["port_unicity"];
     }
 
-    
+
     public function getReplaceMultilineValue()
     {
 

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -252,10 +252,10 @@ class PluginDatainjectionModel extends CommonDBTM
     }
 
     
-    public function getMultilineValueReplace()
+    public function getReplaceMultilineValue()
     {
 
-        return $this->fields["multiline_value_replace"];
+        return $this->fields["replace_multiline_value"];
     }
 
 
@@ -530,7 +530,7 @@ class PluginDatainjectionModel extends CommonDBTM
         $tab[] = [
             'id'            => 87,
             'table'         => $this->getTable(),
-            'field'         => 'multiline_value_replace',
+            'field'         => 'replace_multiline_value',
             'name'          => __('Replacing the value of multiline text fields', 'datainjection'),
             'datatype'      => 'bool',
         ];
@@ -771,7 +771,7 @@ class PluginDatainjectionModel extends CommonDBTM
         echo "</td>";
         echo "<td>" . __('Replacing the value of multiline text fields', 'datainjection') . "</td>";
         echo "<td>";
-        Dropdown::showYesNo("multiline_value_replace", $this->fields['multiline_value_replace']);
+        Dropdown::showYesNo("replace_multiline_value", $this->fields['replace_multiline_value']);
         echo "</td>";
         echo "</td></tr>";
         if ($ID > 0) {


### PR DESCRIPTION
- If a new value for a multiline_text field starts with "#replace", the old value is completely replaced instead of being concatenated.
- The "#replace" tag is removed before storing the new value.
- Default behavior remains unchanged for other cases.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [x] This change requires a documentation update.

## Description

- It fixes #438 
- This PR modifies the behavior of multiline_text fields:
    - If a new value starts with #replace, the old value is completely replaced instead of being concatenated.
    - The #replace tag is removed before storing the new value.
    - The default concatenation behavior remains unchanged when the tag is not present.
