### PR TITLE
Add notes search option in BlacklistedOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add option to `replace` (instead of `append`)  the value of multiline text fields (e.g. `comment`)
 
+### Fixed
+
+- Move `Notepads` search options to the Black List option
+
 ## [2.14.1] - 2024-12-27
 
 ### Added

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -361,11 +361,12 @@ class PluginDatainjectionCommonInjectionLib
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-       //2 : id
+       // 2 : id
        // 19 : date_mod
        // 80 : entity
        // 121 : date_creation
-        $blacklist = [2, 19, 80, 121, 201, 202, 203, 204];
+       // 200 : notepad
+        $blacklist = [2, 19, 80, 121, 200, 201, 202, 203, 204];
 
         $raw_options_to_blacklist = [];
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -366,7 +366,17 @@ class PluginDatainjectionCommonInjectionLib
        // 80 : entity
        // 121 : date_creation
        // 200 : notepad
-        $blacklist = [2, 19, 80, 121, 200, 201, 202, 203, 204];
+        $blacklist = [
+            2,   // id
+            19,  // last update
+            80,  // completename
+            121, // creation date
+            200, // notepad - content
+            201, // notepad - creation date
+            202, // notepad - writer
+            203, // notepad - last update
+            204, // notepad - last updater
+        ];
 
         $raw_options_to_blacklist = [];
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38104
- Here is a brief description of what this PR does
Previously, it was possible to add a single note to an element, but now it's possible to add several. However, since note management has been modified to integrate this functionality, importing is not possible on the element side, and this causes the rest of the injection to crash. It must be added by importing notes directly.

## Screenshots (if appropriate):
