### PR TITLE
fix(User): Error modal generated by “pdffont” field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use `global`  configuration for injection links
 - Escape  data when check if already exist
+- Fix `pdffont` field error for users
 
 ## [Unreleased]
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -916,7 +916,9 @@ class PluginDatainjectionCommonInjectionLib
      **/
     private function setValueForItemtype($itemtype, $field, $value, $fromdb = false)
     {
-
+        if ($itemtype === User::class && $field === "pdffont" && $fromdb) {
+            return;
+        }
        // TODO awfull hack, text ftom CSV set more than once, so check if "another" value
         if (isset($this->values[$itemtype][$field]) && $this->values[$itemtype][$field] != $value) {
            // Data set twice (probably CSV + Additional info)


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38252
- The ‘pdffont’ field belongs to the glpi_users table and is used to select the desired font for PDF export. This field is not directly modifiable in the user form, but in the user's personal preferences. This means that each time a user is imported, this non-blocking error appears when viewing the import report, as the ‘pdffont’ field is never available during import.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c47ea632-b4cb-4dfc-bc68-6d1d99a0f120)

