### PR TITLE
fix: using GLPI_ROOT if defined of set to relative path

### DIFF
--- a/ajax/dropdownChooseField.php
+++ b/ajax/dropdownChooseField.php
@@ -30,7 +30,8 @@
 
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "dropdownChooseField.php")) {
-    include '../../../inc/includes.php';
+    defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+    require GLPI_ROOT . '/inc/includes.php';
     header("Content-Type: text/html; charset=UTF-8");
     Html::header_nocache();
 }

--- a/ajax/dropdownMandatory.php
+++ b/ajax/dropdownMandatory.php
@@ -30,7 +30,8 @@
 
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "dropdownMandatory.php")) {
-    include '../../../inc/includes.php';
+    defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+    require GLPI_ROOT . '/inc/includes.php';
     header("Content-Type: text/html; charset=UTF-8");
     Html::header_nocache();
 }

--- a/ajax/dropdownSelectModel.php
+++ b/ajax/dropdownSelectModel.php
@@ -30,7 +30,8 @@
 
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "dropdownSelectModel.php")) {
-    include '../../../inc/includes.php';
+    defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+    require GLPI_ROOT . '/inc/includes.php';
     header("Content-Type: text/html; charset=UTF-8");
     Html::header_nocache();
 }

--- a/ajax/injection.php
+++ b/ajax/injection.php
@@ -30,7 +30,8 @@
 
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "injection.php")) {
-    include '../../../inc/includes.php';
+    defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+    require GLPI_ROOT . '/inc/includes.php';
     header("Content-Type: text/html; charset=UTF-8");
     Html::header_nocache();
 }

--- a/ajax/results.php
+++ b/ajax/results.php
@@ -30,7 +30,8 @@
 
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "results.php")) {
-    include '../../../inc/includes.php';
+    defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+    require GLPI_ROOT . '/inc/includes.php';
     header("Content-Type: text/html; charset=UTF-8");
     Html::header_nocache();
 }

--- a/front/clientinjection.form.php
+++ b/front/clientinjection.form.php
@@ -28,7 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
 
 Session::checkRight("plugin_datainjection_use", READ);
 

--- a/front/export.csv.php
+++ b/front/export.csv.php
@@ -28,7 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
 
 Session::checkRight(PluginDatainjectionClientInjection::$rightname, READ);
 

--- a/front/export.pdf.php
+++ b/front/export.pdf.php
@@ -28,7 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
 
 Session::checkRight(PluginDatainjectionClientInjection::$rightname, READ);
 

--- a/front/info.form.php
+++ b/front/info.form.php
@@ -28,7 +28,9 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
+
 Session::checkLoginUser();
 
 /* Update mappings */

--- a/front/mapping.form.php
+++ b/front/mapping.form.php
@@ -28,7 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
 
 Session::checkRight('plugin_datainjection_model', UPDATE);
 

--- a/front/model.form.php
+++ b/front/model.form.php
@@ -28,7 +28,9 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
+
 Session::checkLoginUser();
 
 if (!isset($_GET["id"])) {

--- a/front/model.php
+++ b/front/model.php
@@ -28,7 +28,9 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
+
 Session::checkLoginUser();
 
 Html::header(

--- a/front/popup.php
+++ b/front/popup.php
@@ -28,7 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
-require '../../../inc/includes.php';
+defined('GLPI_ROOT') || define('GLPI_ROOT', '../../..');
+require GLPI_ROOT . '/inc/includes.php';
 
 Session::checkLoginUser();
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Versions:
- GLPI: 11.0.0-rc3
- DataInjection: 2.15.0-beta2

With Docker, GLPI is installed in `/var/www/glpi` by default and the marketplace directory is `/var/glpi/marketplace`. So the `includes.php` requirements is broken with this relative path. This MR use `GLPI_ROOT` variable if defined (else it's a relative path).

## Screenshots (if appropriate):
