### PR TITLE
fix(migration): remove Task completed message during plugin update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix the `Task completed` message during plugin update
+
 ## [2.14.3] - 2025-09-16
 
 ### Fixed
 
 - Fix `License` injection
+
 
 ## [2.14.2] - 2025-08-22
 

--- a/hook.php
+++ b/hook.php
@@ -220,8 +220,6 @@ function plugin_datainjection_uninstall()
 
 function plugin_datainjection_migration_2141_2150(Migration $migration)
 {
-    $migration->setVersion('2.15.0');
-
     $migration->addField(
         'glpi_plugin_datainjection_models',
         'replace_multiline_value',
@@ -233,9 +231,6 @@ function plugin_datainjection_migration_2141_2150(Migration $migration)
 
 function plugin_datainjection_migration_2121_2122(Migration $migration)
 {
-
-    $migration->setVersion('2.12.2');
-
    //remove useless field
     $migration->dropField("glpi_plugin_datainjection_models", "perform_network_connection");
 
@@ -248,8 +243,6 @@ function plugin_datainjection_migration_290_2100(Migration $migration)
 {
     /** @var DBmysql $DB */
     global $DB;
-
-    $migration->setVersion('2.10.0');
 
     $migration->addPostQuery(
         $DB->buildUpdate(
@@ -274,8 +267,6 @@ function plugin_datainjection_migration_264_270(Migration $migration)
     /** @var DBmysql $DB */
     global $DB;
 
-    $migration->setVersion('2.7.0');
-
     $migration->addPostQuery(
         $DB->buildUpdate(
             'glpi_plugin_datainjection_mappings',
@@ -299,8 +290,6 @@ function plugin_datainjection_migration_251_252(Migration $migration)
     /** @var DBmysql $DB */
     global $DB;
 
-    $migration->setVersion('2.5.2');
-
     if (
         $DB->tableExists('glpi_plugin_datainjection_models')
         && $DB->fieldExists('glpi_plugin_datainjection_models', 'date_mod')
@@ -321,8 +310,6 @@ function plugin_datainjection_migration_24_250(Migration $migration)
 {
     /** @var DBmysql $DB */
     global $DB;
-
-    $migration->setVersion('2.5.0');
 
     if (
         $DB->tableExists('glpi_plugin_datainjection_models')
@@ -353,8 +340,6 @@ function plugin_datainjection_upgrade23_240(Migration $migration)
 {
     /** @var DBmysql $DB */
     global $DB;
-
-    $migration->setVersion('2.4.0');
 
     if ($DB->tableExists('glpi_plugin_datainjection_profiles')) {
         if ($DB->fieldExists('glpi_plugin_datainjection_profiles', 'ID')) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39063
- When an update to the datainjection plugin is performed, the message “Task completed” is displayed once it is finished. This fix removes this message because it is only present for this plugin.

## Screenshots (if appropriate):
<img width="572" height="1203" alt="image" src="https://github.com/user-attachments/assets/6eb71930-369a-48d9-a2e2-4b35eb3b384f" />

