### PR TITLE
Fix import behavior for SoftwareLicense in CommonDropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.14.3] - 2025-09-16
+
+### Fixed
+
+- Fix `License` injection
+
 ## [2.14.2] - 2025-08-22
 
 ### Fixed

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1689,7 +1689,7 @@ class PluginDatainjectionCommonInjectionLib
                 $add,
                 $this->rights
             );
-        } elseif ($item instanceof CommonDropdown && $add) {
+        } elseif ($item instanceof CommonDropdown && $add && !($item instanceof SoftwareLicense)) {
             $newID = $item->import($toinject);
         } else {
             if ($add) {


### PR DESCRIPTION
This fix modifies the import logic to explicitly ignore SoftwareLicense objects in the CommonDropdown import block. 
