### PR TITLE
Fix - User field updates and email import

### DIFF
--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1657,11 +1657,13 @@ class PluginDatainjectionCommonInjectionLib
                 //If field is a dropdown and value is '', then replace it by 0
                 $toinject[$key] = self::DROPDOWN_EMPTY_VALUE;
             } else {
-                // Skip empty values for fields that are not explicitly set to avoid SQL errors
-                // particularly for integer fields that cannot accept empty strings
+                // Skip empty values for fields that cannot accept empty strings during updates
                 if ($value === self::EMPTY_VALUE && !$add) {
-                    // Skip this field during update if value is empty
-                    continue;
+                    // Check if the field is nullable using the injection class method
+                    if (method_exists($injectionClass, 'isNullable') && !$injectionClass->isNullable($key)) {
+                        // Skip this field during update if value is empty and field is not nullable
+                        continue;
+                    }
                 }
                 $toinject[$key] = $value;
             }

--- a/inc/userinjection.class.php
+++ b/inc/userinjection.class.php
@@ -59,7 +59,20 @@ class PluginDatainjectionUserInjection extends User implements PluginDatainjecti
 
     public function isNullable($field)
     {
-        return true; // By default, all fields can be null
+        // Fields that cannot accept empty string values and should use their default values instead
+        $non_nullable_fields = [
+            'use_mode',
+            'highcontrast_css',
+            'default_central_tab',
+            'entities_id',
+            'profiles_id',
+            'is_active',
+            'is_deleted',
+            'authtype',
+            'auths_id'
+        ];
+
+        return !in_array($field, $non_nullable_fields);
     }
 
 
@@ -101,6 +114,9 @@ class PluginDatainjectionUserInjection extends User implements PluginDatainjecti
         $tab[101]['displaytype']   = 'relation';
         $tab[101]['relationclass'] = 'Profile_User';
         $tab[101]['relationfield'] = $tab[101]['linkfield'];
+
+        // Add email option to make it importable with the correct linkfield
+        $tab[5]['linkfield'] = 'useremails_id';  // Map email field to useremails_id for injection
 
        //Remove some options because some fields cannot be imported
         $blacklist     = PluginDatainjectionCommonInjectionLib::getBlacklistedOptions(get_parent_class($this));
@@ -172,19 +188,34 @@ class PluginDatainjectionUserInjection extends User implements PluginDatainjecti
             && $rights['add_dropdown']
             && Session::haveRight('user', UPDATE)
         ) {
-            if (
-                !countElementsInTable(
-                    "glpi_useremails",
-                    [
-                        'users_id' => $values['User']['id'],
-                        'email'    => $values['User']['useremails_id'],
-                    ]
-                )
-            ) {
-                $useremail       = new UserEmail();
-                $tmp['users_id'] = $values['User']['id'];
-                $tmp['email']    = $values['User']['useremails_id'];
-                $useremail->add($tmp);
+            $email = trim($values['User']['useremails_id']);
+
+            // Validate email format
+            if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                // Check if this email doesn't already exist for this user
+                if (
+                    !countElementsInTable(
+                        "glpi_useremails",
+                        [
+                            'users_id' => $values['User']['id'],
+                            'email'    => $email,
+                        ]
+                    )
+                ) {
+                    $useremail = new UserEmail();
+                    $tmp = [
+                        'users_id'   => $values['User']['id'],
+                        'email'      => $email,
+                        'is_default' => 1  // Set as default email if it's the first one
+                    ];
+
+                    // Check if user already has emails, if so don't set as default
+                    if (countElementsInTable("glpi_useremails", ['users_id' => $values['User']['id']])) {
+                        $tmp['is_default'] = 0;
+                    }
+
+                    $useremail->add($tmp);
+                }
             }
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39825
- Here is a brief description of what this PR does

**Problem:**
- SQL errors when updating users with empty integer fields (`use_mode`, `highcontrast_css`, `default_central_tab`)
- User emails not properly imported during injection
- Existing users not updated with new data during import

**Solution:**
- Enhanced `isNullable()` method to properly handle fields that cannot accept empty strings
- Fixed email import by correcting the `useremails_id` field mapping and validation
- Improved email handling in `processAfterInsertOrUpdate()` with proper validation and duplicate checking

**Changes:**
- Modified `PluginDatainjectionUserInjection::isNullable()` to return `false` for integer fields that require default values
- Added proper email field mapping with `linkfield` set to `useremails_id`
- Enhanced email processing with validation and default email flag management
- Prevents SQL errors from empty string values in integer columns


## Screenshots (if appropriate):
