### PR TITLE
PR : Fix responsible group visibility after injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix crash when injection model has no mandatory fields defined
 - Fix models created on parent entities can't be used on child entites
+- Fix responsible group injection payload normalization so group remains visible in GLPI after import
 
 ## [2.15.4] - 2026-03-16
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1688,16 +1688,25 @@ class PluginDatainjectionCommonInjectionLib
                 $toinject[$key] = $value;
             }
 
-            // handle new format for group type specification
-            // restricting to group_item relations only
-            if (($key === "groups_id_tech" || $key === "groups_id" || $key === "groups_id_normal") && $option['table'] == getTableForItemType(Group::class) && !empty($option) && isset($option['joinparams']['beforejoin']['table']) && $option['joinparams']['beforejoin']['table'] === getTableForItemType(Group_Item::class) && isset($option['joinparams']['beforejoin']['joinparams']['condition']['NEWTABLE.type'])) {
-                $group_type = $option['joinparams']['beforejoin']['joinparams']['condition']['NEWTABLE.type'];
-                // depending on the type, set the correct field (_groups_id_tech => array or _groups_id => array)
-                // and unset the old one (groups_id_tech => int or groups_id => int or groups_id_normal => int)
-                if ($group_type == Group_Item::GROUP_TYPE_TECH) {
-                    $toinject["_groups_id_tech"] = [$value];
+            // Normalize group assignment fields to GLPI relation payload keys.
+            // Some search options do not expose a stable joinparams shape, but GLPI
+            // still expects _groups_id/_groups_id_tech arrays when saving equipment groups.
+            if (
+                in_array($key, ['groups_id_tech', 'groups_id', 'groups_id_normal'], true)
+                && !empty($option)
+                && isset($option['table'])
+                && $option['table'] === getTableForItemType(Group::class)
+            ) {
+                $group_type = null;
+                if (isset($option['joinparams']['beforejoin']['joinparams']['condition']['NEWTABLE.type'])) {
+                    $group_type = $option['joinparams']['beforejoin']['joinparams']['condition']['NEWTABLE.type'];
+                }
+
+                // Keep explicit technical group semantics from key or metadata.
+                if ($key === 'groups_id_tech' || $group_type == Group_Item::GROUP_TYPE_TECH) {
+                    $toinject['_groups_id_tech'] = [$value];
                 } else {
-                    $toinject["_groups_id"] = [$value];
+                    $toinject['_groups_id'] = [$value];
                 }
                 unset($toinject[$key]);
             }

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1697,6 +1697,7 @@ class PluginDatainjectionCommonInjectionLib
                 && isset($option['table'])
                 && $option['table'] === getTableForItemType(Group::class)
             ) {
+                $normalized_value = $toinject[$key];
                 $group_type = null;
                 if (isset($option['joinparams']['beforejoin']['joinparams']['condition']['NEWTABLE.type'])) {
                     $group_type = $option['joinparams']['beforejoin']['joinparams']['condition']['NEWTABLE.type'];
@@ -1704,9 +1705,9 @@ class PluginDatainjectionCommonInjectionLib
 
                 // Keep explicit technical group semantics from key or metadata.
                 if ($key === 'groups_id_tech' || $group_type == Group_Item::GROUP_TYPE_TECH) {
-                    $toinject['_groups_id_tech'] = [$value];
+                    $toinject['_groups_id_tech'] = [$normalized_value];
                 } else {
-                    $toinject['_groups_id'] = [$value];
+                    $toinject['_groups_id'] = [$normalized_value];
                 }
                 unset($toinject[$key]);
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [X] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #606
- Normalize `groups_id`, `groups_id_normal`, and `groups_id_tech` to the GLPI relation payload keys expected by equipment save flows
- Preserve technical-group handling with `_groups_id_tech`
- Fall back to key-based normalization when search option join metadata is incomplete
- Add an unreleased changelog entry
