### PR TITLE
FIX / User update imports failing due to cookie_token overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix retrieval of dropdown and multiline values containing special characters
+- Fix repeated User updates failing with `Data too long for column cookie_token` by excluding token fields from update payloads (backport of PR #566 from GLPI 11-compatible line)
 
 ## [2.14.4] - 2025-11-25
 

--- a/inc/userinjection.class.php
+++ b/inc/userinjection.class.php
@@ -169,6 +169,21 @@ class PluginDatainjectionUserInjection extends User implements PluginDatainjecti
         return $fields;
     }
 
+    /**
+     * @param array $values
+     *
+     * @return void
+     */
+    public function reformat(&$values)
+    {
+        // Avoid re-encrypting already encrypted tokens during user updates.
+        $tokens = ['password_forget_token', 'personal_token', 'api_token', 'cookie_token'];
+        foreach ($tokens as $token) {
+            if (isset($values['User'][$token])) {
+                unset($values['User'][$token]);
+            }
+        }
+    }
 
     /**
     * @param array $values


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43800
- When importing updates for User records multiple times, the second run could fail with:
`Data too long for column cookie_token.`During update, token fields already stored in DB were included again in the update payload.
GLPI encrypts those token fields during update, so already-encrypted values were encrypted again, increasing size until `cookie_token` exceeded column capacity.
This issue is already fixed in the GLPI 11 compatible line via PR #566 , included in the 2.15.x series.
This PR brings the same protection to the GLPI 10 compatible branch.