### PR TITLE
fix/ escape SQL values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,4 @@ dist/
 vendor/
 .gh_token
 *.min.*
-
-
-var/phpunit
+var/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ vendor/
 .gh_token
 *.min.*
 
+
+var/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- fix escape SQL values
+
 ## [2.15.6] - 2026-05-05
 
 ### Fixed

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1903,7 +1903,7 @@ class PluginDatainjectionCommonInjectionLib
                 //If it's a computer device
                 if ($item instanceof CommonDevice) {
                     $sql .= " WHERE `designation` = '" .
-                    $this->getValueByItemtypeAndName($itemtype, 'designation') . "'";
+                    $DB->escape($this->getValueByItemtypeAndName($itemtype, 'designation')) . "'";
                 } elseif ($item instanceof CommonDBRelation) {
                     //Type is a relation : check it this relation still exists
                     //Define the side of the relation to use
@@ -1920,13 +1920,13 @@ class PluginDatainjectionCommonInjectionLib
                         $destination_itemtype = $item::$itemtype_2;
                     }
                     $where .= " AND `$source_id`='" .
-                    $this->getValueByItemtypeAndName($itemtype, $source_id) . "'";
+                    $DB->escape($this->getValueByItemtypeAndName($itemtype, $source_id)) . "'";
                     if ($item->isField('itemtype')) {
                         $where .= " AND `$source_itemtype`='" .
-                        $this->getValueByItemtypeAndName($itemtype, $source_itemtype) . "'";
+                        $DB->escape($this->getValueByItemtypeAndName($itemtype, $source_itemtype)) . "'";
                     }
                     $where .= " AND `" . $destination_id . "`='" .
-                    $this->getValueByItemtypeAndName($itemtype, $destination_id) . "'";
+                    $DB->escape($this->getValueByItemtypeAndName($itemtype, $destination_id)) . "'";
                     $sql   .= " WHERE 1 " . $where;
                 } else {
                     //Type is not a relation
@@ -1958,7 +1958,7 @@ class PluginDatainjectionCommonInjectionLib
                         } else {
                             //Type cannot be recursive
                             $where_entity = " AND `entities_id` = '" .
-                            $this->getValueByItemtypeAndName($itemtype, 'entities_id') . "'";
+                            $DB->escape($this->getValueByItemtypeAndName($itemtype, 'entities_id')) . "'";
                         }
                     } else { //If no entity assignment for this itemtype
                         $where_entity = "";
@@ -1972,25 +1972,25 @@ class PluginDatainjectionCommonInjectionLib
                                     $email = $DB->escape($this->getValueByItemtypeAndName($itemtype, $field));
                                     $where .= " AND `id` IN (SELECT `users_id` FROM glpi_useremails WHERE `email` = '$email') ";
                                 } else {
-                                    $where .= " AND `" . $field . "`='" . (string) $this->getValueByItemtypeAndName($itemtype, $field) . "'";
+                                    $where .= " AND `" . $field . "`='" . $DB->escape((string) $this->getValueByItemtypeAndName($itemtype, $field)) . "'";
                                 }
                             }
                         }
                     } else {
                         //Table contains an itemtype field
                         if ($injectionClass->isField('itemtype')) {
-                            $where .= " AND `itemtype` = '" . $this->getValueByItemtypeAndName(
+                            $where .= " AND `itemtype` = '" . $DB->escape($this->getValueByItemtypeAndName(
                                 $itemtype,
                                 'itemtype',
-                            ) . "'";
+                            )) . "'";
                         }
 
                         //Table contains an items_id field
                         if ($injectionClass->isField('items_id')) {
-                            $where .= " AND `items_id` = '" . $this->getValueByItemtypeAndName(
+                            $where .= " AND `items_id` = '" . $DB->escape($this->getValueByItemtypeAndName(
                                 $itemtype,
                                 'items_id',
-                            ) . "'";
+                            )) . "'";
                         }
                     }
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -27,6 +27,8 @@
  * @link      https://github.com/pluginsGLPI/datainjection
  * -------------------------------------------------------------------------
  */
+use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QuerySubQuery;
 use Glpi\Exception\Http\HttpException;
 use Glpi\Features\AssignableItem;
 
@@ -1865,7 +1867,6 @@ class PluginDatainjectionCommonInjectionLib
         /** @var DBmysql $DB */
         global $DB;
 
-        $where    = "";
         $continue = true;
 
         $injectionClass->getOptions($this->primary_type);
@@ -1893,17 +1894,15 @@ class PluginDatainjectionCommonInjectionLib
             if (!$continue) {
                 $this->values[$itemtype]['id'] = self::ITEM_NOT_FOUND;
             } else {
-                $sql = "SELECT *
-                    FROM `" . $injectionClass->getTable() . "`";
-
                 if (!is_a($itemtype, CommonDBTM::class, true)) {
                     throw new HttpException(500, 'Class ' . $itemtype . ' is not a valid class');
                 }
-                $item = new $itemtype();
+                $item  = new $itemtype();
+                $where = [];
+
                 //If it's a computer device
                 if ($item instanceof CommonDevice) {
-                    $sql .= " WHERE `designation` = '" .
-                    $DB->escape($this->getValueByItemtypeAndName($itemtype, 'designation')) . "'";
+                    $where['designation'] = $this->getValueByItemtypeAndName($itemtype, 'designation');
                 } elseif ($item instanceof CommonDBRelation) {
                     //Type is a relation : check it this relation still exists
                     //Define the side of the relation to use
@@ -1919,49 +1918,41 @@ class PluginDatainjectionCommonInjectionLib
                         $source_itemtype      = $item::$itemtype_1;
                         $destination_itemtype = $item::$itemtype_2;
                     }
-                    $where .= " AND `$source_id`='" .
-                    $DB->escape($this->getValueByItemtypeAndName($itemtype, $source_id)) . "'";
+                    $where[$source_id]      = $this->getValueByItemtypeAndName($itemtype, $source_id);
+                    $where[$destination_id] = $this->getValueByItemtypeAndName($itemtype, $destination_id);
                     if ($item->isField('itemtype')) {
-                        $where .= " AND `$source_itemtype`='" .
-                        $DB->escape($this->getValueByItemtypeAndName($itemtype, $source_itemtype)) . "'";
+                        $where[$source_itemtype] = $this->getValueByItemtypeAndName($itemtype, $source_itemtype);
                     }
-                    $where .= " AND `" . $destination_id . "`='" .
-                    $DB->escape($this->getValueByItemtypeAndName($itemtype, $destination_id)) . "'";
-                    $sql   .= " WHERE 1 " . $where;
                 } else {
                     //Type is not a relation
 
                     //Type can be deleted
                     if ($injectionClass->maybeDeleted()) {
-                        $where .= " AND `is_deleted` = '0' ";
+                        $where['is_deleted'] = 0;
                     }
 
                     //Type can be a template
                     if ($injectionClass->maybeTemplate()) {
-                        $where .= " AND `is_template` = '0' ";
+                        $where['is_template'] = 0;
                     }
 
                     //Type can be assigned to an entity
                     if ($injectionClass->isEntityAssign()) {
                         //Type can be recursive
                         if ($injectionClass->maybeRecursive()) {
-                            $where_entity = getEntitiesRestrictRequest(
-                                " AND",
-                                $injectionClass->getTable(),
-                                "entities_id",
-                                $this->getValueByItemtypeAndName(
-                                    $itemtype,
+                            $where = array_merge(
+                                $where,
+                                getEntitiesRestrictCriteria(
+                                    $injectionClass->getTable(),
                                     'entities_id',
+                                    $this->getValueByItemtypeAndName($itemtype, 'entities_id'),
+                                    true,
                                 ),
-                                true,
                             );
                         } else {
                             //Type cannot be recursive
-                            $where_entity = " AND `entities_id` = '" .
-                            $DB->escape($this->getValueByItemtypeAndName($itemtype, 'entities_id')) . "'";
+                            $where['entities_id'] = $this->getValueByItemtypeAndName($itemtype, 'entities_id');
                         }
-                    } else { //If no entity assignment for this itemtype
-                        $where_entity = "";
                     }
 
                     //Add mandatory fields to the query only if it's the primary_type to be injected
@@ -1969,44 +1960,49 @@ class PluginDatainjectionCommonInjectionLib
                         foreach ($this->mandatory_fields[$itemtype] as $field => $is_mandatory) {
                             if ($is_mandatory) {
                                 if ($item instanceof User && $field == "useremails_id") {
-                                    $email = $DB->escape($this->getValueByItemtypeAndName($itemtype, $field));
-                                    $where .= " AND `id` IN (SELECT `users_id` FROM glpi_useremails WHERE `email` = '$email') ";
+                                    $where['id'] = new QuerySubQuery([
+                                        'SELECT' => 'users_id',
+                                        'FROM'   => 'glpi_useremails',
+                                        'WHERE'  => ['email' => $this->getValueByItemtypeAndName($itemtype, $field)],
+                                    ]);
                                 } else {
-                                    $where .= " AND `" . $field . "`='" . $DB->escape((string) $this->getValueByItemtypeAndName($itemtype, $field)) . "'";
+                                    $where[$field] = $this->getValueByItemtypeAndName($itemtype, $field);
                                 }
                             }
                         }
                     } else {
                         //Table contains an itemtype field
                         if ($injectionClass->isField('itemtype')) {
-                            $where .= " AND `itemtype` = '" . $DB->escape($this->getValueByItemtypeAndName(
-                                $itemtype,
-                                'itemtype',
-                            )) . "'";
+                            $where['itemtype'] = $this->getValueByItemtypeAndName($itemtype, 'itemtype');
                         }
 
                         //Table contains an items_id field
                         if ($injectionClass->isField('items_id')) {
-                            $where .= " AND `items_id` = '" . $DB->escape($this->getValueByItemtypeAndName(
-                                $itemtype,
-                                'items_id',
-                            )) . "'";
+                            $where['items_id'] = $this->getValueByItemtypeAndName($itemtype, 'items_id');
                         }
                     }
 
                     //Add additional parameters specific to this itemtype (or function checkPresent exists)
                     if (method_exists($injectionClass, 'checkPresent')) {
-                        $where .= $injectionClass->checkPresent($this->values, $options);
+                        $extra = trim((string) $injectionClass->checkPresent($this->values, $options));
+                        $extra = trim(preg_replace('/^\s*AND\s+/i', '', $extra));
+                        if ($extra !== '') {
+                            $where[] = new QueryExpression($extra);
+                        }
                     }
-                    $sql .= " WHERE 1 " . $where_entity . " " . $where;
                 }
-                $result = $DB->doQuery($sql);
-                if ($DB->numrows($result) > 0) {
-                    $db_fields = $DB->fetchAssoc($result);
+
+                $result = $DB->request([
+                    'FROM'  => $injectionClass->getTable(),
+                    'WHERE' => $where,
+                ]);
+
+                if (count($result) > 0) {
+                    $db_fields = $result->current();
                     foreach ($db_fields as $key => $value) {
                         $this->setValueForItemtype($itemtype, $key, $value, true);
                     }
-                    $this->setValueForItemtype($itemtype, 'id', $DB->result($result, 0, 'id'));
+                    $this->setValueForItemtype($itemtype, 'id', $db_fields['id']);
                 } else {
                     $this->setValueForItemtype($itemtype, 'id', self::ITEM_NOT_FOUND);
                 }

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -27,7 +27,7 @@
  * @link      https://github.com/pluginsGLPI/datainjection
  * -------------------------------------------------------------------------
  */
-use Glpi\DBAL\QueryExpression;
+
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Exception\Http\HttpException;
 use Glpi\Features\AssignableItem;

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1984,10 +1984,9 @@ class PluginDatainjectionCommonInjectionLib
 
                     //Add additional parameters specific to this itemtype (or function checkPresent exists)
                     if (method_exists($injectionClass, 'checkPresent')) {
-                        $extra = trim((string) $injectionClass->checkPresent($this->values, $options));
-                        $extra = trim(preg_replace('/^\s*AND\s+/i', '', $extra));
-                        if ($extra !== '') {
-                            $where[] = new QueryExpression($extra);
+                        $extra = $injectionClass->checkPresent($this->values, $options);
+                        if (is_array($extra) && count($extra) > 0) {
+                            $where = array_merge($where, $extra);
                         }
                     }
                 }

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1985,8 +1985,19 @@ class PluginDatainjectionCommonInjectionLib
                     //Add additional parameters specific to this itemtype (or function checkPresent exists)
                     if (method_exists($injectionClass, 'checkPresent')) {
                         $extra = $injectionClass->checkPresent($this->values, $options);
-                        if (is_array($extra) && count($extra) > 0) {
-                            $where = array_merge($where, $extra);
+                        if (is_array($extra)) {
+                            if (count($extra) > 0) {
+                                $where = array_merge($where, $extra);
+                            }
+                        } elseif (!empty($extra)) {
+                            trigger_error(
+                                sprintf(
+                                    '%s::checkPresent() must return an array, %s returned instead.',
+                                    get_class($injectionClass),
+                                    gettype($extra),
+                                ),
+                                E_USER_WARNING,
+                            );
                         }
                     }
                 }

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -993,6 +993,7 @@ class PluginDatainjectionModel extends CommonDBTM
                     ),
                 ];
             }
+            unset($_FILES['filename']);
         }
 
         //If file has not the right extension, reject it and delete if

--- a/inc/networkportinjection.class.php
+++ b/inc/networkportinjection.class.php
@@ -184,11 +184,11 @@ class PluginDatainjectionNetworkportInjection extends NetworkPort implements Plu
     * @param array $fields_toinject    array
     * @param array $options            array
    **/
-    public function checkPresent($fields_toinject = [], $options = [])
+    public function checkPresent($fields_toinject = [], $options = []): array
     {
-
         return $this->getUnicityRequest($fields_toinject['NetworkPort'], $options['checks']);
     }
+
 
 
     /**
@@ -245,40 +245,38 @@ class PluginDatainjectionNetworkportInjection extends NetworkPort implements Plu
     * @param array $fields_toinject    array    the fields to insert into DB
     * @param array $options            array
     *
-    * @return string the sql where clause
+    * @return array
    **/
-    public function getUnicityRequest($fields_toinject = [], $options = [])
+    public function getUnicityRequest($fields_toinject = [], $options = []): array
     {
-
-        $where = "";
-
+        $where = [];
         switch ($options['port_unicity']) {
             case PluginDatainjectionCommonInjectionLib::UNICITY_NETPORT_LOGICAL_NUMBER:
-                $where .= " AND `logical_number` = '" . ($fields_toinject["logical_number"] ?? '') . "'";
+                $where['logical_number'] = $fields_toinject['logical_number'] ?? '';
                 break;
 
             case PluginDatainjectionCommonInjectionLib::UNICITY_NETPORT_LOGICAL_NUMBER_MAC:
-                $where .= " AND `logical_number` = '" . ($fields_toinject["logical_number"] ?? '') . "'
-                        AND `mac` = '" . ($fields_toinject["mac"] ?? '') . "'";
+                $where['logical_number'] = $fields_toinject['logical_number'] ?? '';
+                $where['mac']            = $fields_toinject['mac'] ?? '';
                 break;
 
             case PluginDatainjectionCommonInjectionLib::UNICITY_NETPORT_LOGICAL_NUMBER_NAME:
-                $where .= " AND `logical_number` = '" . ($fields_toinject["logical_number"] ?? '') . "'
-                        AND `name` = '" . ($fields_toinject["name"] ?? '') . "'";
+                $where['logical_number'] = $fields_toinject['logical_number'] ?? '';
+                $where['name']           = $fields_toinject['name'] ?? '';
                 break;
 
             case PluginDatainjectionCommonInjectionLib::UNICITY_NETPORT_LOGICAL_NUMBER_NAME_MAC:
-                $where .= " AND `logical_number` = '" . ($fields_toinject["logical_number"] ?? '') . "'
-                        AND `name` = '" . ($fields_toinject["name"] ?? '') . "'
-                        AND `mac` = '" . ($fields_toinject["mac"] ?? '') . "'";
+                $where['logical_number'] = $fields_toinject['logical_number'] ?? '';
+                $where['name']           = $fields_toinject['name'] ?? '';
+                $where['mac']            = $fields_toinject['mac'] ?? '';
                 break;
 
             case PluginDatainjectionCommonInjectionLib::UNICITY_NETPORT_MACADDRESS:
-                $where .= " AND `mac` = '" . ($fields_toinject["mac"] ?? '') . "'";
+                $where['mac'] = $fields_toinject['mac'] ?? '';
                 break;
 
             case PluginDatainjectionCommonInjectionLib::UNICITY_NETPORT_NAME:
-                $where .= " AND `name` = '" . ($fields_toinject["name"] ?? '') . "'";
+                $where['name'] = $fields_toinject['name'] ?? '';
                 break;
         }
 

--- a/inc/softwarelicenseinjection.class.php
+++ b/inc/softwarelicenseinjection.class.php
@@ -200,14 +200,16 @@ class PluginDatainjectionSoftwareLicenseInjection extends SoftwareLicense implem
     /**
     * @param array $fields_toinject    array
     * @param array $options            array
+    * @retrun array
    **/
-    public function checkPresent($fields_toinject = [], $options = [])
+    public function checkPresent($fields_toinject = [], $options = []): array
     {
-
         if ($options['itemtype'] != 'SoftwareLicense') {
-            return (" AND `softwares_id` = '" . $fields_toinject['Software']['id'] . "'
-                   AND `name` = '" . $fields_toinject['SoftwareLicense']['name'] . "'");
+            return [
+                'softwares_id' => $fields_toinject['Software']['id'],
+                'name'         => $fields_toinject['SoftwareLicense']['name'],
+            ];
         }
-        return "";
+        return [];
     }
 }

--- a/inc/softwareversioninjection.class.php
+++ b/inc/softwareversioninjection.class.php
@@ -195,14 +195,16 @@ class PluginDatainjectionSoftwareVersionInjection extends SoftwareVersion implem
     /**
     * @param array $fields_toinject    array
     * @param array $options            array
+    * @return array
    **/
-    public function checkPresent($fields_toinject = [], $options = [])
+    public function checkPresent($fields_toinject = [], $options = []): array
     {
-
         if ($options['itemtype'] != 'SoftwareVersion') {
-            return (" AND `softwares_id` = '" . $fields_toinject['Software']['id'] . "'
-                   AND `name` = '" . $fields_toinject['SoftwareVersion']['name'] . "'");
+            return [
+                'softwares_id' => $fields_toinject['Software']['id'],
+                'name'         => $fields_toinject['SoftwareVersion']['name'],
+            ];
         }
-        return "";
+        return [];
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<phpunit
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    testdox="true"
+    cacheDirectory="var/phpunit"
+>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
+    <testsuites>
+        <testsuite name="Tests">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+$current_plugin_folder = basename(realpath(__DIR__ . '/../'));
+
+require __DIR__ . '/../../../tests/bootstrap.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (!Plugin::isPluginActive($current_plugin_folder)) {
+    throw new RuntimeException("Plugin $current_plugin_folder is not active in the test database");
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,33 @@
 <?php
 
+/**
+ * -------------------------------------------------------------------------
+ * DataInjection plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of DataInjection.
+ *
+ * DataInjection is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * DataInjection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DataInjection. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2007-2023 by DataInjection plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/datainjection
+ * -------------------------------------------------------------------------
+ */
+
 $current_plugin_folder = basename(realpath(__DIR__ . '/../'));
 
 require __DIR__ . '/../../../tests/bootstrap.php';

--- a/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
+++ b/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
@@ -1,5 +1,34 @@
 <?php
 
+/**
+ * -------------------------------------------------------------------------
+ * Escalade plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Escalade.
+ *
+ * Escalade is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Escalade is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Escalade. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2015-2023 by Escalade plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/escalade
+ * -------------------------------------------------------------------------
+ */
+
+
 namespace GlpiPlugin\Datainjection\Tests\Unit;
 
 use Glpi\Tests\DbTestCase;

--- a/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
+++ b/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
@@ -51,6 +51,3 @@ final class CommonInjectionLibDataAlreadyInDbTest extends DbTestCase
         self::assertSame($manufacturer->getID(), $values['id']);
     }
 }
-
-
-

--- a/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
+++ b/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace GlpiPlugin\Datainjection\Tests\Unit;
+
+use Glpi\Tests\DbTestCase;
+use Manufacturer;
+use PluginDatainjectionCommonInjectionLib;
+
+require_once dirname(__DIR__, 2) . '/inc/injectioninterface.class.php';
+require_once dirname(__DIR__, 2) . '/inc/commoninjectionlib.class.php';
+require_once dirname(__DIR__, 2) . '/inc/manufacturerinjection.class.php';
+
+final class CommonInjectionLibDataAlreadyInDbTest extends DbTestCase
+{
+    public function testDataAlreadyInDbHandlesApostropheInMandatoryFieldValue(): void
+    {
+        $manufacturer_name = "O'Brien Manufacturer";
+        $manufacturer = $this->createItem(Manufacturer::class, [
+            'name' => $manufacturer_name,
+        ]);
+
+        $injection_class = new \PluginDatainjectionManufacturerInjection();
+        $common_injection_lib = new PluginDatainjectionCommonInjectionLib(
+            $injection_class,
+            [
+                'Manufacturer' => [
+                    'name' => $manufacturer_name,
+                ],
+            ],
+            [
+                'mandatory_fields' => [
+                    'Manufacturer' => [
+                        'name' => true,
+                    ],
+                ],
+            ],
+        );
+
+        $invoke_data_already_in_db = \Closure::bind(
+            function ($injection_class, string $itemtype): void {
+                $this->dataAlreadyInDB($injection_class, $itemtype);
+            },
+            $common_injection_lib,
+            PluginDatainjectionCommonInjectionLib::class,
+        );
+
+        $invoke_data_already_in_db($injection_class, 'Manufacturer');
+
+        $values = $common_injection_lib->getValuesForItemtype('Manufacturer');
+        self::assertIsArray($values);
+        self::assertSame($manufacturer->getID(), $values['id']);
+    }
+}
+
+
+

--- a/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
+++ b/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
@@ -2,28 +2,30 @@
 
 /**
  * -------------------------------------------------------------------------
- * Escalade plugin for GLPI
+ * DataInjection plugin for GLPI
  * -------------------------------------------------------------------------
  *
  * LICENSE
  *
- * This file is part of Escalade.
+ * This file is part of DataInjection.
  *
- * Escalade is free software; you can redistribute it and/or modify
+ * DataInjection is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  *
- * Escalade is distributed in the hope that it will be useful,
+ * DataInjection is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Escalade. If not, see <http://www.gnu.org/licenses/>.
+ * along with DataInjection. If not, see <http://www.gnu.org/licenses/>.
  * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2007-2023 by DataInjection plugin team.
  * @copyright Copyright (C) 2015-2023 by Escalade plugin team.
  * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/datainjection
  * @link      https://github.com/pluginsGLPI/escalade
  * -------------------------------------------------------------------------
  */

--- a/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
+++ b/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
@@ -23,10 +23,8 @@
  * along with DataInjection. If not, see <http://www.gnu.org/licenses/>.
  * -------------------------------------------------------------------------
  * @copyright Copyright (C) 2007-2023 by DataInjection plugin team.
- * @copyright Copyright (C) 2015-2023 by Escalade plugin team.
  * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
  * @link      https://github.com/pluginsGLPI/datainjection
- * @link      https://github.com/pluginsGLPI/escalade
  * -------------------------------------------------------------------------
  */
 

--- a/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
+++ b/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
@@ -28,7 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-
 namespace GlpiPlugin\Datainjection\Tests\Unit;
 
 use Glpi\Tests\DbTestCase;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44078
- SQL queries in dataAlreadyInDB concatenated field values directly without escaping, causing a syntax error when names contain apostrophes . All affected concatenations now use escape().