### PR TITLE
fix(commoninjectionlib.class.php): normalize group assignment fields for assignable items only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - fix escape SQL values
+- normalize group assignment fields for assignable items only
 
 ## [2.15.6] - 2026-05-05
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1700,11 +1700,13 @@ class PluginDatainjectionCommonInjectionLib
             // Normalize group assignment fields to GLPI relation payload keys.
             // Some search options do not expose a stable joinparams shape, but GLPI
             // still expects _groups_id/_groups_id_tech arrays when saving equipment groups.
+            // Only apply to items using the AssignableItem trait.
             if (
                 in_array($key, ['groups_id_tech', 'groups_id', 'groups_id_normal'], true)
                 && !empty($option)
                 && isset($option['table'])
                 && $option['table'] === getTableForItemType(Group::class)
+                && Toolbox::hasTrait($item->getType(), AssignableItem::class)
             ) {
                 $normalized_value = $toinject[$key];
                 $group_type = null;

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -1701,6 +1701,7 @@ class PluginDatainjectionCommonInjectionLib
             // Some search options do not expose a stable joinparams shape, but GLPI
             // still expects _groups_id/_groups_id_tech arrays when saving equipment groups.
             // Only apply to items using the AssignableItem trait.
+            // Non-AssignableItem types store groups_id as a plain FK; skip array normalisation for them.
             if (
                 in_array($key, ['groups_id_tech', 'groups_id', 'groups_id_normal'], true)
                 && !empty($option)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,8 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-use function Safe\realpath;
-
 $current_plugin_folder = basename(realpath(__DIR__ . '/../'));
 
 require __DIR__ . '/../../../tests/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,11 +28,21 @@
  * -------------------------------------------------------------------------
  */
 
+use function Safe\realpath;
+
 $current_plugin_folder = basename(realpath(__DIR__ . '/../'));
 
 require __DIR__ . '/../../../tests/bootstrap.php';
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-if (!Plugin::isPluginActive($current_plugin_folder)) {
-    throw new RuntimeException("Plugin $current_plugin_folder is not active in the test database");
+$plugin = new Plugin();
+$plugin->checkPluginState('datainjection');
+$plugin->getFromDBbyDir('datainjection');
+
+if (!$plugin->isInstalled('datainjection')) {
+    $plugin->install($plugin->getID());
+}
+
+if (!$plugin->isActivated('datainjection')) {
+    $plugin->activate($plugin->getID());
 }

--- a/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
+++ b/tests/unit/CommonInjectionLibDataAlreadyInDbTest.php
@@ -30,6 +30,8 @@
 
 namespace GlpiPlugin\Datainjection\Tests\Unit;
 
+use PluginDatainjectionManufacturerInjection;
+use Closure;
 use Glpi\Tests\DbTestCase;
 use Manufacturer;
 use PluginDatainjectionCommonInjectionLib;
@@ -47,7 +49,7 @@ final class CommonInjectionLibDataAlreadyInDbTest extends DbTestCase
             'name' => $manufacturer_name,
         ]);
 
-        $injection_class = new \PluginDatainjectionManufacturerInjection();
+        $injection_class = new PluginDatainjectionManufacturerInjection();
         $common_injection_lib = new PluginDatainjectionCommonInjectionLib(
             $injection_class,
             [
@@ -64,7 +66,7 @@ final class CommonInjectionLibDataAlreadyInDbTest extends DbTestCase
             ],
         );
 
-        $invoke_data_already_in_db = \Closure::bind(
+        $invoke_data_already_in_db = Closure::bind(
             function ($injection_class, string $itemtype): void {
                 $this->dataAlreadyInDB($injection_class, $itemtype);
             },

--- a/tests/unit/GroupInjectionTest.php
+++ b/tests/unit/GroupInjectionTest.php
@@ -40,7 +40,7 @@ use PluginDatainjectionCommonInjectionLib;
 
 final class GroupInjectionTest extends DbTestCase
 {
-    public static function AssigneGroupToInjectedAssignableItemProvider(): array
+    public static function assignGroupToInjectedAssignableItemProvider(): array
     {
         return [
             'with_groups_id' => [
@@ -80,7 +80,7 @@ final class GroupInjectionTest extends DbTestCase
 
     /**
      *
-     * @dataProvider assigneGroupToInjectedAssignableItemProvider
+     * @dataProvider assignGroupToInjectedAssignableItemProvider
      */
     public function testAssigneGroupToInjectedAssignableItem(
         string $group_field,
@@ -300,7 +300,7 @@ final class GroupInjectionTest extends DbTestCase
     /**
      * Updating an existing non assignable item via injection must also persist groups_id.
      */
-    public function testGroupIsUpdatedOnExistingNonAssugnableItem(): void
+    public function testGroupIsUpdatedOnExistingNonAssignableItem(): void
     {
         $group = $this->createItem(Group::class, [
             'name'        => 'GG_ADC_DRN_EDL',

--- a/tests/unit/GroupInjectionTest.php
+++ b/tests/unit/GroupInjectionTest.php
@@ -1,0 +1,360 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * DataInjection plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of DataInjection.
+ *
+ * DataInjection is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * DataInjection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DataInjection. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2007-2023 by DataInjection plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/datainjection
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Datainjection\Tests\Unit;
+
+use PluginDatainjectionComputerInjection;
+use PluginDatainjectionITILCategoryInjection;
+use Glpi\Tests\DbTestCase;
+use Group;
+use ITILCategory;
+use Computer;
+use PluginDatainjectionCommonInjectionLib;
+
+final class GroupInjectionTest extends DbTestCase
+{
+    public static function AssigneGroupToInjectedAssignableItemProvider(): array
+    {
+        return [
+            'with_groups_id' => [
+                'group_field'      => 'groups_id_tech',
+                'injected_data'    => [
+                    'Computer' => [
+                        'name'      => 'Test_Computer_with_groups_id',
+                        'groups_id' => 'GG_ADC_DRN_EDL',
+                    ],
+                ],
+                'mandatory_fields' => ['Computer' => ['name' => true]],
+                'expect_group'     => true,
+            ],
+            'with_groups_id_normal' => [
+                'group_field'      => 'groups_id',
+                'injected_data'    => [
+                    'Computer' => [
+                        'name'            => 'Test_Computer_with_groups_id_normal',
+                        'groups_id_normal' => 'GG_ADC_DRN_EDL',
+                    ],
+                ],
+                'mandatory_fields' => ['Computer' => ['name' => true]],
+                'expect_group'     => true,
+            ],
+            'without_group' => [
+                'group_field'      => 'groups_id',
+                'injected_data'    => [
+                    'Computer' => [
+                        'name' => 'Test_Computer_without_group',
+                    ],
+                ],
+                'mandatory_fields' => ['Computer' => ['name' => true]],
+                'expect_group'     => false,
+            ],
+        ];
+    }
+
+    /**
+     *
+     * @dataProvider assigneGroupToInjectedAssignableItemProvider
+     */
+    public function testAssigneGroupToInjectedAssignableItem(
+        string $group_field,
+        array $injected_data,
+        array $mandatory_fields,
+        bool $expect_group
+    ): void {
+        $group = null;
+        if ($expect_group) {
+            $group = $this->createItem(Group::class, [
+                'name'         => 'GG_ADC_DRN_EDL',
+                'entities_id'  => 0,
+                'is_recursive' => 1,
+            ]);
+        }
+
+        $injection_class = new PluginDatainjectionComputerInjection();
+
+        $lib = new PluginDatainjectionCommonInjectionLib(
+            $injection_class,
+            $injected_data,
+            [
+                'rights' => [
+                    'can_add'      => true,
+                    'can_update'   => true,
+                    'add_dropdown' => true,
+                ],
+                'mandatory_fields' => $mandatory_fields,
+                'entities_id'      => 0,
+            ],
+        );
+
+        $lib->processAddOrUpdate();
+        $results = $lib->getInjectionResults();
+
+        self::assertSame(PluginDatainjectionCommonInjectionLib::SUCCESS, $results['status']);
+        self::assertSame(PluginDatainjectionCommonInjectionLib::IMPORT_ADD, $results['type']);
+
+        $item_id = $results['Computer'];
+        self::assertGreaterThan(0, $item_id);
+
+        $item = new Computer();
+        self::assertTrue($item->getFromDB($item_id));
+
+        $field_value = $item->fields[$group_field] ?? [];
+        if (!is_array($field_value)) {
+            $field_value = [$field_value];
+        }
+
+        if ($expect_group) {
+            self::assertContains($group->getID(), $field_value);
+        } else {
+            self::assertEmpty($field_value);
+        }
+    }
+
+    public static function groupIsAssignedToInjectedNonAssignableItemProvider(): array
+    {
+        return [
+            'with_groups_id' => [
+                'injected_data'    => [
+                    'ITILCategory' => [
+                        'name'      => 'Test_ITILCategory_with_groups_id',
+                        'groups_id' => 'GG_ADC_DRN_EDL',
+                    ],
+                ],
+                'mandatory_fields' => ['ITILCategory' => ['name' => true]],
+                'expect_group'     => true,
+            ],
+            'without_group' => [
+                'injected_data'    => [
+                    'ITILCategory' => [
+                        'name' => 'Test_ITILCategory_without_group',
+                    ],
+                ],
+                'mandatory_fields' => ['ITILCategory' => ['name' => true]],
+                'expect_group'     => false,
+            ],
+        ];
+    }
+
+    /**
+     *
+     * @dataProvider groupIsAssignedToInjectedNonAssignableItemProvider
+     */
+    public function testGroupIsAssignedToInjectedNonAssignableItem(
+        array $injected_data,
+        array $mandatory_fields,
+        bool $expect_group
+    ): void {
+        $group = null;
+        if ($expect_group) {
+            $group = $this->createItem(Group::class, [
+                'name'         => 'GG_ADC_DRN_EDL',
+                'entities_id'  => 0,
+                'is_recursive' => 1,
+            ]);
+        }
+
+        $injection_class = new PluginDatainjectionITILCategoryInjection();
+
+        $lib = new PluginDatainjectionCommonInjectionLib(
+            $injection_class,
+            $injected_data,
+            [
+                'rights' => [
+                    'can_add'      => true,
+                    'can_update'   => true,
+                    'add_dropdown' => true,
+                ],
+                'mandatory_fields' => $mandatory_fields,
+                'entities_id'      => 0,
+            ],
+        );
+
+        $lib->processAddOrUpdate();
+        $results = $lib->getInjectionResults();
+
+        self::assertSame(PluginDatainjectionCommonInjectionLib::SUCCESS, $results['status']);
+        self::assertSame(PluginDatainjectionCommonInjectionLib::IMPORT_ADD, $results['type']);
+
+        $item_id = $results['ITILCategory'];
+        self::assertGreaterThan(0, $item_id);
+
+        $category = new ITILCategory();
+        self::assertTrue($category->getFromDB($item_id));
+
+        if ($expect_group) {
+            self::assertSame(
+                $group->getID(),
+                (int) $category->fields['groups_id'],
+            );
+        } else {
+            self::assertSame(0, (int) $category->fields['groups_id']);
+        }
+    }
+
+    public static function groupIsUpdatedOnExistingAssignableItemProvider(): array
+    {
+        return [
+            'with_groups_id' => [
+                'group_field'      => 'groups_id_tech',
+                'injected_data'    => [
+                    'Computer' => [
+                        'name'      => 'Test_Computer_update_groups_id',
+                        'groups_id' => 'GG_ADC_DRN_EDL',
+                    ],
+                ],
+                'mandatory_fields' => ['Computer' => ['name' => true]],
+            ],
+            'with_groups_id_normal' => [
+                'group_field'      => 'groups_id',
+                'injected_data'    => [
+                    'Computer' => [
+                        'name'            => 'Test_Computer_update_groups_id_normal',
+                        'groups_id_normal' => 'GG_ADC_DRN_EDL',
+                    ],
+                ],
+                'mandatory_fields' => ['Computer' => ['name' => true]],
+            ],
+        ];
+    }
+
+    /**
+     * Updating an existing AssignableItem (Computer) via injection must route the group through
+     * the AssignableItem normalisation path and persist it in Group_Item.
+     *
+     * @dataProvider groupIsUpdatedOnExistingAssignableItemProvider
+     */
+    public function testGroupIsUpdatedOnExistingAssignableItem(
+        string $group_field,
+        array $injected_data,
+        array $mandatory_fields
+    ): void {
+        $group = $this->createItem(Group::class, [
+            'name'         => 'GG_ADC_DRN_EDL',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $computer = $this->createItem(Computer::class, [
+            'name'        => $injected_data['Computer']['name'],
+            'entities_id' => 0,
+        ]);
+
+        $injection_class = new PluginDatainjectionComputerInjection();
+
+        $lib = new PluginDatainjectionCommonInjectionLib(
+            $injection_class,
+            $injected_data,
+            [
+                'rights' => [
+                    'can_add'      => true,
+                    'can_update'   => true,
+                    'add_dropdown' => true,
+                ],
+                'mandatory_fields' => $mandatory_fields,
+                'entities_id'      => 0,
+            ],
+        );
+
+        $lib->processAddOrUpdate();
+        $results = $lib->getInjectionResults();
+
+        self::assertSame(PluginDatainjectionCommonInjectionLib::SUCCESS, $results['status']);
+        self::assertSame(PluginDatainjectionCommonInjectionLib::IMPORT_UPDATE, $results['type']);
+
+        $computer->getFromDB($computer->getID());
+
+        $field_value = $computer->fields[$group_field] ?? [];
+        if (!is_array($field_value)) {
+            $field_value = [$field_value];
+        }
+        self::assertContains($group->getID(), $field_value);
+    }
+
+    /**
+     * Updating an existing non assignable item via injection must also persist groups_id.
+     */
+    public function testGroupIsUpdatedOnExistingNonAssugnableItem(): void
+    {
+        $group = $this->createItem(Group::class, [
+            'name'        => 'GG_ADC_DRN_EDL',
+            'entities_id' => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $category = $this->createItem(ITILCategory::class, [
+            'name'        => 'Demande',
+            'entities_id' => 0,
+            'groups_id'   => 0,
+        ]);
+
+        $injection_class = new PluginDatainjectionITILCategoryInjection();
+
+        $lib = new PluginDatainjectionCommonInjectionLib(
+            $injection_class,
+            [
+                'ITILCategory' => [
+                    'name'      => 'Demande',
+                    'groups_id' => 'GG_ADC_DRN_EDL',
+                ],
+            ],
+            [
+                'rights' => [
+                    'can_add'      => true,
+                    'can_update'   => true,
+                    'add_dropdown' => true,
+                ],
+                'mandatory_fields' => [
+                    'ITILCategory' => [
+                        'name' => true,
+                    ],
+                ],
+                'entities_id' => 0,
+            ],
+        );
+
+        $lib->processAddOrUpdate();
+        $results = $lib->getInjectionResults();
+
+        self::assertSame(
+            PluginDatainjectionCommonInjectionLib::SUCCESS,
+            $results['status'],
+        );
+        self::assertSame(
+            PluginDatainjectionCommonInjectionLib::IMPORT_UPDATE,
+            $results['type'],
+        );
+
+        $category->getFromDB($category->getID());
+        self::assertSame(
+            $group->getID(),
+            (int) $category->fields['groups_id'],
+        );
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44708
- the block that normalizes group assignment fields (example : `groups_id → _groups_id` (array)) was triggered for any item with a search option pointing to `glpi_groups`. Some items (example: `ITILCategory`) store `groups_id` as a direct integer FK, not via `Group_Item`. For these items, the `_groups_id` array this block produced was silently ignored, leaving `groups_id = 0`.
- Fix: Check that the item being injected has the `AssignableItem`  trait to the guard condition. The rewrite now only happens for items like `Computer` that actually has this trait and expect group assignments through `Group_Item` relations.
