### PR TITLE
Fix/confirm dialog js escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- Fix : confirm dialog js escaping
+
 ## [2.15.8] - 2026-06-24
 
 ### Fixed

--- a/ajax/injection.php
+++ b/ajax/injection.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+use function Safe\unserialize;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "injection.php")) {
     header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/results.php
+++ b/ajax/results.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+use function Safe\unserialize;
+
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "results.php")) {
     header("Content-Type: text/html; charset=UTF-8");

--- a/front/clientinjection.form.php
+++ b/front/clientinjection.form.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+use function Safe\unserialize;
+
 Session::checkRight("plugin_datainjection_use", READ);
 
 Html::header(

--- a/inc/clientinjection.class.php
+++ b/inc/clientinjection.class.php
@@ -41,6 +41,7 @@ use function Safe\json_decode;
 use function Safe\json_encode;
 use function Safe\readfile;
 use function Safe\unlink;
+use function Safe\unserialize;
 
 class PluginDatainjectionClientInjection
 {

--- a/inc/mapping.class.php
+++ b/inc/mapping.class.php
@@ -32,6 +32,7 @@ use Glpi\Application\View\TemplateRenderer;
 
 use function Safe\ob_get_clean;
 use function Safe\ob_start;
+use function Safe\unserialize;
 
 class PluginDatainjectionMapping extends CommonDBTM
 {

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -33,6 +33,7 @@ use Glpi\Application\View\TemplateRenderer;
 use function Safe\json_decode;
 use function Safe\realpath;
 use function Safe\tempnam;
+use function Safe\unserialize;
 
 /**
  * -------------------------------------------------------------------------

--- a/templates/clientinjection_upload_file.html.twig
+++ b/templates/clientinjection_upload_file.html.twig
@@ -69,7 +69,7 @@
             {% else %}
                 {% set message = __("Watch out, you're about to inject data into GLPI. Are you sure you want to do it ?", 'datainjection') %}
             {% endif %}
-            <input type="submit" class="btn btn-primary" name="upload" value="{{ submit_label }}" onclick="return window.confirm('{{ message }}');">
+            <input type="submit" class="btn btn-primary" name="upload" value="{{ submit_label }}" onclick="return window.confirm('{{ message|e('js') }}');">
         {% else %}
             <input type="submit" class="btn btn-primary" name="upload" value="{{ submit_label }}">
         {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45139
- The apostrophe in the message was breaking the JavaScript; the confirmation only appeared in Italian. Fixed with |e('js').

