### PR TITLE
Fix negative default value on models entities_id column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix : confirm dialog js escaping
+- Fix negative default value (`-1`) on `glpi_plugin_datainjection_models.entities_id`
 
 ## [2.15.8] - 2026-06-24
 

--- a/hook.php
+++ b/hook.php
@@ -53,6 +53,7 @@ function plugin_datainjection_install()
             plugin_datainjection_migration_264_270($migration);
             plugin_datainjection_migration_2121_2122($migration);
             plugin_datainjection_migration_2141_2150($migration);
+            plugin_datainjection_migration_2158_2159($migration);
             break;
 
         case 0:
@@ -173,6 +174,7 @@ function plugin_datainjection_install()
             plugin_datainjection_migration_290_2100($migration);
             plugin_datainjection_migration_2121_2122($migration);
             plugin_datainjection_migration_2141_2150($migration);
+            plugin_datainjection_migration_2158_2159($migration);
             break;
 
         default:
@@ -224,6 +226,33 @@ function plugin_datainjection_migration_2141_2150(Migration $migration)
         'bool',
     );
 
+    $migration->executeMigration();
+}
+
+function plugin_datainjection_migration_2158_2159(Migration $migration)
+{
+    $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+    // Fix remaining legacy data (old schema stored private models with `entities_id = -1`).
+    if (countElementsInTable("glpi_plugin_datainjection_models", ['entities_id' => -1])) {
+        $migration->addPostQuery(
+            "UPDATE `glpi_plugin_datainjection_models`
+                SET `is_private` = '1', `entities_id` = '0', `is_recursive` = '1'
+              WHERE `entities_id` = '-1'",
+        );
+    }
+
+    // Fix the negative column default inherited from the old schema. Databases installed
+    // before `plugin_datainjection_update170_20()` kept `entities_id ... default '-1'`,
+    // which prevents GLPI 11 `migration:unsigned_keys` from converting the column to unsigned.
+    $migration->changeField(
+        'glpi_plugin_datainjection_models',
+        'entities_id',
+        'entities_id',
+        "int {$default_key_sign} NOT NULL default '0'",
+    );
+
+    $migration->migrationOneTable('glpi_plugin_datainjection_models');
     $migration->executeMigration();
 }
 

--- a/hook.php
+++ b/hook.php
@@ -234,8 +234,10 @@ function plugin_datainjection_migration_2158_2159(Migration $migration)
     $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
     // Fix remaining legacy data (old schema stored private models with `entities_id = -1`).
+    // Must run *before* the changeField() below: the column is converted to
+    // `unsigned`, which would mangle the `-1` values before this cleanup could match them.
     if (countElementsInTable("glpi_plugin_datainjection_models", ['entities_id' => -1])) {
-        $migration->addPostQuery(
+        $migration->addPreQuery(
             "UPDATE `glpi_plugin_datainjection_models`
                 SET `is_private` = '1', `entities_id` = '0', `is_recursive` = '1'
               WHERE `entities_id` = '-1'",

--- a/hook.php
+++ b/hook.php
@@ -252,7 +252,6 @@ function plugin_datainjection_migration_2158_2159(Migration $migration)
         "int {$default_key_sign} NOT NULL default '0'",
     );
 
-    $migration->migrationOneTable('glpi_plugin_datainjection_models');
     $migration->executeMigration();
 }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45445
- Databases upgraded from old datainjection schemas kept a `-1` default on
`glpi_plugin_datainjection_models.entities_id`, which blocked GLPI 11's
`migration:unsigned_keys`. Adds a migration resetting the column default to 0
(and fixing any remaining `-1` rows).


