### PR TITLE
Fix: avoid crash when Safe unserialize is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix crash on mapping/injection screens (`Safe\unserialize` not shipped by GLPI core yet)
+
 ## [2.15.9] - 2026-08-04
 
 ### Fixed

--- a/ajax/injection.php
+++ b/ajax/injection.php
@@ -28,8 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-use function Safe\unserialize;
-
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "injection.php")) {
     header("Content-Type: text/html; charset=UTF-8");
@@ -37,5 +35,5 @@ if (strpos($_SERVER['PHP_SELF'], "injection.php")) {
 }
 
 Session::checkCentralAccess();
-$model = unserialize($_SESSION['datainjection']['currentmodel']);
+$model = PluginDatainjectionSession::unserialize($_SESSION['datainjection']['currentmodel']);
 PluginDatainjectionClientInjection::showInjectionForm($model, $_SESSION['glpiactive_entity']);

--- a/ajax/results.php
+++ b/ajax/results.php
@@ -28,8 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-use function Safe\unserialize;
-
 // Direct access to file
 if (strpos($_SERVER['PHP_SELF'], "results.php")) {
     header("Content-Type: text/html; charset=UTF-8");
@@ -37,5 +35,5 @@ if (strpos($_SERVER['PHP_SELF'], "results.php")) {
 }
 
 Session::checkCentralAccess();
-$model = unserialize($_SESSION['datainjection']['currentmodel']);
+$model = PluginDatainjectionSession::unserialize($_SESSION['datainjection']['currentmodel']);
 PluginDatainjectionClientInjection::showResultsForm($model);

--- a/front/clientinjection.form.php
+++ b/front/clientinjection.form.php
@@ -28,8 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-use function Safe\unserialize;
-
 Session::checkRight("plugin_datainjection_use", READ);
 
 Html::header(
@@ -41,7 +39,7 @@ Html::header(
 );
 
 if (isset($_SESSION['datainjection']['go'])) {
-    $model = unserialize($_SESSION['datainjection']['currentmodel']);
+    $model = PluginDatainjectionSession::unserialize($_SESSION['datainjection']['currentmodel']);
     PluginDatainjectionClientInjection::showInjectionForm($model, $_SESSION['glpiactive_entity']);
 } elseif (isset($_POST['upload'])) {
     $model = new PluginDatainjectionModel();

--- a/inc/clientinjection.class.php
+++ b/inc/clientinjection.class.php
@@ -41,7 +41,6 @@ use function Safe\json_decode;
 use function Safe\json_encode;
 use function Safe\readfile;
 use function Safe\unlink;
-use function Safe\unserialize;
 
 class PluginDatainjectionClientInjection
 {
@@ -195,7 +194,7 @@ class PluginDatainjectionClientInjection
 
         Profile::getCurrent()->disable();
 
-        $model = unserialize($_SESSION['datainjection']['currentmodel']);
+        $model = PluginDatainjectionSession::unserialize($_SESSION['datainjection']['currentmodel']);
         $model->loadSpecificModel();
         $entities_id = $_SESSION['glpiactive_entity'];
         $lines_json  = PluginDatainjectionSession::getParam('injection_lines');
@@ -328,7 +327,7 @@ class PluginDatainjectionClientInjection
         self::stripslashes_array($error_lines);
 
         if (!empty($error_lines)) {
-            $model = unserialize(PluginDatainjectionSession::getParam('currentmodel'));
+            $model = PluginDatainjectionSession::unserialize(PluginDatainjectionSession::getParam('currentmodel'));
             $file  = PLUGIN_DATAINJECTION_UPLOAD_DIR . PluginDatainjectionSession::getParam('file_name');
 
             $mappings = $model->getMappings();

--- a/inc/mapping.class.php
+++ b/inc/mapping.class.php
@@ -32,7 +32,6 @@ use Glpi\Application\View\TemplateRenderer;
 
 use function Safe\ob_get_clean;
 use function Safe\ob_start;
-use function Safe\unserialize;
 
 class PluginDatainjectionMapping extends CommonDBTM
 {
@@ -100,7 +99,7 @@ class PluginDatainjectionMapping extends CommonDBTM
     public static function showFormMappings(PluginDatainjectionModel $model)
     {
         $canedit = $model->can($model->fields['id'], UPDATE);
-        $lines = isset($_SESSION['datainjection']['lines']) ? unserialize($_SESSION['datainjection']['lines']) : [];
+        $lines = isset($_SESSION['datainjection']['lines']) ? PluginDatainjectionSession::unserialize($_SESSION['datainjection']['lines']) : [];
 
         $show_preview = isset($_SESSION['datainjection']['lines']) && !empty($lines);
         $preview_url = '';

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -33,7 +33,6 @@ use Glpi\Application\View\TemplateRenderer;
 use function Safe\json_decode;
 use function Safe\realpath;
 use function Safe\tempnam;
-use function Safe\unserialize;
 
 /**
  * -------------------------------------------------------------------------
@@ -1321,7 +1320,7 @@ class PluginDatainjectionModel extends CommonDBTM
 
         echo "<table class='tab_cadre_fixe'>";
         if (isset($_SESSION['datainjection']['lines'])) {
-            $injectionData = unserialize($_SESSION['datainjection']['lines']);
+            $injectionData = PluginDatainjectionSession::unserialize($_SESSION['datainjection']['lines']);
             $lines         = $injectionData->getData();
             $nblines       = $_SESSION['datainjection']['nblines'];
             $model         = self::getInstanceByModelID($models_id);

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -35,6 +35,24 @@ use function Safe\unlink;
 class PluginDatainjectionSession
 {
     /**
+    * Unserialize a value, using Safe\unserialize() when available
+    * (not shipped by GLPI core yet, see thecodingmachine/safe >= 3.4.0)
+    *
+    * @param string $data  the serialized value
+    *
+    * @return mixed the unserialized value
+   **/
+    public static function unserialize(string $data)
+    {
+        if (function_exists('Safe\unserialize')) {
+            return \Safe\unserialize($data);
+        }
+        // @phpstan-ignore theCodingMachineSafe.function
+        return unserialize($data);
+    }
+
+
+    /**
     * Get a parameter from the HTTP session
     *
     * @param string $param  the parameter to get


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45747
- The mapping and injection screens crashed with an UndefinedFunctionError because `Safe\unserialize()` is not shipped yet by any released GLPI 11.0.x core version. Session data is now unserialized through a shared helper that uses the Safe variant only when it actually exists, falling back to native `unserialize()` otherwise.

## Screenshots (if appropriate):
