### PR TITLE
Fix(core):Fix model selector validation and access control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Move to iterator
 - Fix various minor bugs in the import/export workflow
 - Fix an issue where data are not formatted when coming from a field plugin's custom field.
+- Fix model selector validation and access control
 
 ## [2.15.10] - 2026-08-07
 

--- a/front/mapping.form.php
+++ b/front/mapping.form.php
@@ -34,9 +34,21 @@ Session::checkRight('plugin_datainjection_model', UPDATE);
 if (isset($_POST["update"])) {
     $at_least_one_mandatory = false;
     $mapping                = new PluginDatainjectionMapping();
+    $existing               = new PluginDatainjectionMapping();
+
+    $models_id = (int) ($_POST['models_id'] ?? 0);
+    $model     = new PluginDatainjectionModel();
+    $model->check($models_id, UPDATE);
 
     foreach ($_POST['data'] as $id => $mapping_infos) {
-        $mapping_infos['id'] = $id;
+        if (
+            !$existing->getFromDB((int) $id)
+            || (int) $existing->fields['models_id'] !== $models_id
+        ) {
+            continue;
+        }
+
+        $mapping_infos['id'] = (int) $id;
 
         //If no field selected, reset other values
         if ($mapping_infos['value'] == PluginDatainjectionInjectionType::NO_VALUE) {
@@ -64,12 +76,9 @@ if (isset($_POST["update"])) {
             true,
         );
     } else {
-        $model = new PluginDatainjectionModel();
-        $model->getFromDB($_POST['models_id']);
-
         if ($model->fields['step'] != PluginDatainjectionModel::READY_TO_USE_STEP) {
             PluginDatainjectionModel::changeStep(
-                $_POST['models_id'],
+                $models_id,
                 PluginDatainjectionModel::OTHERS_STEP,
             );
             Session::setActiveTab('PluginDatainjectionModel', 'PluginDatainjectionModel$5');

--- a/front/popup.php
+++ b/front/popup.php
@@ -32,16 +32,20 @@ Session::checkLoginUser();
 
 switch ($_GET["popup"]) {
     case "preview":
+        $models_id = (int) ($_GET['models_id'] ?? 0);
         $model = new PluginDatainjectionModel();
-        $model->check($_GET['models_id'], READ);
+        $model->check($models_id, READ);
         Html::popHeader(__('See the file', 'datainjection'), $_SERVER['PHP_SELF']);
-        PluginDatainjectionModel::showPreviewMappings($_GET['models_id']);
+        PluginDatainjectionModel::showPreviewMappings($models_id);
         Html::popFooter();
         break;
 
     case "log":
+        $models_id = (int) ($_GET['models_id'] ?? 0);
+        $model = new PluginDatainjectionModel();
+        $model->check($models_id, READ);
         Html::popHeader(__('Data injection report', 'datainjection'), $_SERVER['PHP_SELF']);
-        PluginDatainjectionModel::showLogResults($_GET['models_id']);
+        PluginDatainjectionModel::showLogResults($models_id);
         Html::popFooter();
         break;
 }

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -137,7 +137,7 @@ class PluginDatainjectionModel extends CommonDBTM
             return false;
         }
 
-        return self::checkRightOnModel($this->fields['id']);
+        return self::checkRightOnModel((int) ($this->fields['id'] ?? 0));
     }
 
 
@@ -158,7 +158,7 @@ class PluginDatainjectionModel extends CommonDBTM
             return false;
         }
 
-        return self::checkRightOnModel($this->fields['id']);
+        return self::checkRightOnModel((int) ($this->fields['id'] ?? 0));
     }
 
 
@@ -351,10 +351,10 @@ class PluginDatainjectionModel extends CommonDBTM
                 if ($model['entities_id'] == -1) {
                     echo "\n<optgroup label='" . __s('Private') . "'>";
                 } else {
-                    echo "\n<optgroup label=\"" . Dropdown::getDropdownName(
+                    echo "\n<optgroup label=\"" . htmlescape(Dropdown::getDropdownName(
                         "glpi_entities",
                         $model['entities_id'],
-                    ) . '">';
+                    )) . '">';
                 }
 
                 $prev = $model['entities_id'];
@@ -362,8 +362,8 @@ class PluginDatainjectionModel extends CommonDBTM
 
             $selected = $model['id'] == $value ? "selected" : "";
 
-            $comment = $model['comment'] ? "title='" . htmlentities((string) $model['comment'], ENT_QUOTES, 'UTF-8') . "'" : "";
-            echo "\n<option value='" . $model['id'] . sprintf("' %s %s>", $selected, $comment) . $model['name'] . "</option>";
+            $comment = $model['comment'] ? "title='" . htmlescape((string) $model['comment']) . "'" : "";
+            echo "\n<option value='" . $model['id'] . sprintf("' %s %s>", $selected, $comment) . htmlescape($model['name']) . "</option>";
         }
 
         if ($prev >= -1) {
@@ -436,7 +436,7 @@ class PluginDatainjectionModel extends CommonDBTM
 
         foreach ($DB->request($query) as $data) {
             if (
-                self::checkRightOnModel($data['id'])
+                self::checkRightOnModel((int) $data['id'])
                 && class_exists($data['itemtype'])
             ) {
                 $models[] = $data;
@@ -870,7 +870,7 @@ class PluginDatainjectionModel extends CommonDBTM
             return false;
         }
 
-        if (!$input['behavior_add'] && !$input['behavior_update']) {
+        if (!($input['behavior_add'] ?? 0) && !($input['behavior_update'] ?? 0)) {
             Session::addMessageAfterRedirect(
                 __s(
                     'Your model should allow import and/or update of data',
@@ -1251,40 +1251,44 @@ class PluginDatainjectionModel extends CommonDBTM
     }
 
 
-    /**
-    * @param int $models_id
-   **/
-    public static function checkRightOnModel($models_id)
+    public static function checkRightOnModel(int $models_id): bool
     {
         /** @var DBmysql $DB */
         global $DB;
 
-        $continue = true;
-
         $model = new self();
-        if ($model->getFromDB($models_id)) {
-            $query = "(SELECT `itemtype`
-                    FROM `glpi_plugin_datainjection_models`
-                    WHERE `id` = '" . $models_id . "')
-                    UNION (SELECT DISTINCT `itemtype`
-                        FROM `glpi_plugin_datainjection_mappings`
-                        WHERE `models_id` = '" . $models_id . "')
-                    UNION (SELECT DISTINCT `itemtype`
-                        FROM `glpi_plugin_datainjection_infos`
-                        WHERE `models_id` = '" . $models_id . "')";
-            foreach ($DB->doQuery($query) as $data) {
-                if ($data['itemtype'] != PluginDatainjectionInjectionType::NO_VALUE && is_a($data['itemtype'], CommonDBTM::class, true)) {
-                    $item                     = new $data['itemtype']();
-                    $item->fields['itemtype'] = $model->fields['itemtype'];
-                    if (!($item instanceof CommonDBRelation) && !$item->canCreate()) {
-                        $continue = false;
-                        break;
-                    }
-                }
+        if (!$model->getFromDB($models_id)) {
+            //New model being created: no injected itemtype to check yet
+            return true;
+        }
+
+        $itemtypes = [$model->fields['itemtype']];
+
+        foreach (['glpi_plugin_datainjection_mappings', 'glpi_plugin_datainjection_infos'] as $table) {
+            $iterator = $DB->request([
+                'SELECT'   => 'itemtype',
+                'DISTINCT' => true,
+                'FROM'     => $table,
+                'WHERE'    => ['models_id' => $models_id],
+            ]);
+
+            foreach ($iterator as $data) {
+                $itemtypes[] = $data['itemtype'];
             }
         }
 
-        return $continue;
+        foreach (array_unique($itemtypes) as $itemtype) {
+            if ($itemtype == PluginDatainjectionInjectionType::NO_VALUE || !is_a($itemtype, CommonDBTM::class, true)) {
+                continue;
+            }
+
+            $item = new $itemtype();
+            if (!$item->canCreate()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 

--- a/inc/modelcsv.class.php
+++ b/inc/modelcsv.class.php
@@ -160,26 +160,26 @@ class PluginDatainjectionModelcsv extends CommonDBChild
     *
     * @return int the ID of the row in glpi_plugin_datainjection_modelcsv
    **/
-    public function getFromDBByModelID($models_id)
+    public function getFromDBByModelID(int $models_id): int
     {
         /** @var DBmysql $DB */
         global $DB;
 
-        $query = "SELECT `id`
-                FROM `" . $this->getTable() . "`
-                WHERE `models_id` = '" . $models_id . "'";
+        $iterator = $DB->request([
+            'SELECT' => 'id',
+            'FROM'   => $this->getTable(),
+            'WHERE'  => ['models_id' => $models_id],
+            'LIMIT'  => 1,
+        ]);
 
-        $results = $DB->doQuery($query);
-        $id = 0;
-
-        if ($DB->numrows($results) > 0) {
-            $id = $DB->result($results, 0, 'id');
+        if (count($iterator) > 0) {
+            $id = (int) $iterator->current()['id'];
             $this->getFromDB($id);
         } else {
             $this->getEmpty();
             $tmp = $this->fields;
             $tmp['models_id'] = $models_id;
-            $id  = $this->add($tmp);
+            $id  = (int) $this->add($tmp);
             $this->getFromDB($id);
         }
 

--- a/tests/unit/ModelCheckRightTest.php
+++ b/tests/unit/ModelCheckRightTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * DataInjection plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of DataInjection.
+ *
+ * DataInjection is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * DataInjection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DataInjection. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2007-2023 by DataInjection plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/datainjection
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Datainjection\Tests\Unit;
+
+use Computer;
+use Group;
+use Group_User;
+use PluginDatainjectionMapping;
+use PluginDatainjectionModel;
+use Session;
+use User;
+use Glpi\Tests\DbTestCase;
+
+final class ModelCheckRightTest extends DbTestCase
+{
+    private function createModel(string $itemtype = Computer::class): int
+    {
+        $model = new PluginDatainjectionModel();
+        $models_id = $model->add([
+            'name'            => 'Test_Model_CheckRight_' . $itemtype . '_' . random_int(1, PHP_INT_MAX),
+            'itemtype'        => $itemtype,
+            'filetype'        => 'csv',
+            'entities_id'     => 0,
+            'is_private'      => 0,
+            'behavior_add'    => 1,
+            'behavior_update' => 0,
+            'users_id'        => Session::getLoginUserID(),
+        ]);
+        $this->assertGreaterThan(0, $models_id);
+
+        return (int) $models_id;
+    }
+
+    public function testUnknownModelIsAllowed(): void
+    {
+        $this->login();
+
+        $this->assertTrue(PluginDatainjectionModel::checkRightOnModel(999999));
+    }
+
+    public function testCreationPathReturnsBooleanOnEmptyModel(): void
+    {
+        $this->login();
+
+        $model = new PluginDatainjectionModel();
+        $model->getEmpty();
+
+        $this->assertIsBool($model->canCreateItem());
+    }
+
+    public function testMappedRelationItemtypeWithoutRightsIsDenied(): void
+    {
+        $this->login();
+
+        $models_id  = $this->createModel();
+        $control_id = $this->createModel();
+
+        $mapping = new PluginDatainjectionMapping();
+        $this->assertGreaterThan(0, $mapping->add([
+            'models_id'    => $models_id,
+            'itemtype'     => Group_User::class,
+            'rank'         => 0,
+            'name'         => 'groups_id',
+            'value'        => 'groups_id',
+            'is_mandatory' => 0,
+        ]));
+
+        $this->assertTrue(PluginDatainjectionModel::checkRightOnModel($models_id));
+
+        $_SESSION['glpiactiveprofile'][User::$rightname]  = 0;
+        $_SESSION['glpiactiveprofile'][Group::$rightname] = 0;
+
+        //Control model keeps its own granted itemtype: only the mapped relation may deny
+        $this->assertTrue(PluginDatainjectionModel::checkRightOnModel($control_id));
+        $this->assertFalse(PluginDatainjectionModel::checkRightOnModel($models_id));
+    }
+}

--- a/tests/unit/ModelCsvLookupTest.php
+++ b/tests/unit/ModelCsvLookupTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * DataInjection plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of DataInjection.
+ *
+ * DataInjection is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * DataInjection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DataInjection. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2007-2023 by DataInjection plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/datainjection
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Datainjection\Tests\Unit;
+
+use Session;
+use Glpi\Tests\DbTestCase;
+use PluginDatainjectionModel;
+use PluginDatainjectionModelCsv;
+use TypeError;
+
+final class ModelCsvLookupTest extends DbTestCase
+{
+    private function createModel(): int
+    {
+        $model = new PluginDatainjectionModel();
+        $models_id = $model->add([
+            'name'            => 'Test_ModelCsv_Lookup',
+            'itemtype'        => 'Computer',
+            'filetype'        => 'csv',
+            'entities_id'     => 0,
+            'is_private'      => 0,
+            'behavior_add'    => 1,
+            'behavior_update' => 0,
+            'users_id'        => Session::getLoginUserID(),
+        ]);
+        $this->assertGreaterThan(0, $models_id);
+
+        return (int) $models_id;
+    }
+
+    public function testRowIsCreatedThenReusedForSameModel(): void
+    {
+        $models_id = $this->createModel();
+
+        $csv = new PluginDatainjectionModelCsv();
+        $first = $csv->getFromDBByModelID($models_id);
+
+        $this->assertGreaterThan(0, $first);
+        $this->assertSame($models_id, (int) $csv->fields['models_id']);
+
+        $second = (new PluginDatainjectionModelCsv())->getFromDBByModelID($models_id);
+        $this->assertSame($first, $second);
+    }
+
+    public function testNonNumericModelIdIsRejected(): void
+    {
+        $csv = new PluginDatainjectionModelCsv();
+
+        $this->expectException(TypeError::class);
+        $csv->getFromDBByModelID("id' AND SLEEP(5)-- ");
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- Model identifiers received by the preview and report popups are now validated as integers before being used.
- Model names and entity names are now escaped in the injection model selector.
- The mapping form now verifies that each submitted mapping belongs to the model being edited, and checks the update right on that model.
- Rights on relation itemtypes are now evaluated like any other itemtype when deciding whether a model can be listed and used.


## Screenshots (if appropriate):
