### PR TITLE
Fix: check the right matching the model behavior (#664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix various minor bugs in the import/export workflow (backport of PR #656 from GLPI 11-compatible line)
 - Move network port lookup query to the GLPI DBAL iterator (backport of PR #659 from GLPI 11-compatible line)
 - Fix model selector validation and access control (backport of PR #660 from GLPI 11-compatible line)
+- Fix validation, permissions and entity handling during imports (backport of PR #664 from GLPI 11-compatible line)
+- Improve partial import error reporting (backport of PR #664 from GLPI 11-compatible line)
+- Correct user password import and creation handling (policy, history, expiration and confirmation) (backport of PR #664 from GLPI 11-compatible line)
 
 ## [2.14.4] - 2025-11-25
 

--- a/inc/commoninjectionlib.class.php
+++ b/inc/commoninjectionlib.class.php
@@ -547,24 +547,22 @@ class PluginDatainjectionCommonInjectionLib
 
 
     /**
-    * Get the ID associated with a value from the CSV file
-    *
-    * @param PluginDatainjectionInjectionInterface|null $injectionClass
-    * @param string $itemtype               itemtype of the values to inject
-    * @param array $searchOption           option associated with the field to check
-    * @param string $field                  the field to check
-    * @param string $value                  the value coming from the CSV file
-    * @param boolean $add                    is insertion (true) or update (false) (true by default)
-    *
-    * @return void nothing
-   **/
+     * Get the ID associated with a value from the CSV file
+     *
+     * @param PluginDatainjectionInjectionInterface|null $injectionClass
+     * @param string $itemtype               itemtype of the values to inject
+     * @param array $searchOption           option associated with the field to check
+     * @param string $field                  the field to check
+     * @param string $value                  the value coming from the CSV file
+     *
+     * @return void nothing
+     **/
     private function getFieldValue(
         $injectionClass,
         $itemtype,
         $searchOption,
         $field,
-        $value,
-        $add = true
+        $value
     ) {
         if (isset($searchOption['storevaluein'])) {
             $linkfield = $searchOption['storevaluein'];
@@ -583,13 +581,12 @@ class PluginDatainjectionCommonInjectionLib
                 break;
 
             case 'password':
-               //To add a user password, it's mandatory is give a password and it's confirmation
-               //Here we cannot detect if it's an add or update. We'll handle updates later in the process
-                if ($add && $itemtype == 'User') {
+                //Core needs both the password and its confirmation to validate and hash it, on add as well as on update
+                if ($itemtype == 'User') {
                     $this->setValueForItemtype($itemtype, $linkfield, $value);
-                    //Add field password2 is not already present
+                    //Add field password2 if not already present
                     //(can be present if password was an addtional information)
-                    if (!isset($this->values[$itemtype][$field])) {
+                    if (!isset($this->values[$itemtype][$linkfield . "2"])) {
                         $this->setValueForItemtype($itemtype, $linkfield . "2", $value);
                     }
                 }
@@ -927,7 +924,8 @@ class PluginDatainjectionCommonInjectionLib
      **/
     private function setValueForItemtype($itemtype, $field, $value, $fromdb = false)
     {
-        if ($itemtype === User::class && $field === "pdffont" && $fromdb) {
+        //The stored password is a hash: taking it back from the DB would overwrite the imported one
+        if ($itemtype === User::class && in_array($field, ['pdffont', 'password'], true) && $fromdb) {
             return;
         }
         $injectionClass = self::getInjectionClassInstance($itemtype);
@@ -1577,14 +1575,17 @@ class PluginDatainjectionCommonInjectionLib
                 $newID  = $this->effectiveAddOrUpdate($this->injectionClass, $item, $values, $add);
 
                 if (!$newID) {
-                    $this->results['status'] = self::WARNING;
+                    $this->addCheckWarning(self::WARNING, get_class($item));
                 } else {
                   //Store id of the injected item
                     $this->setValueForItemtype($this->primary_type, 'id', $newID);
 
-                  //If type needs it : process more data after type import
-                    $this->processAfterInsertOrUpdate($this->injectionClass, $add);
-                  //$this->results['status'] = self::SUCCESS;
+                    //If type needs it : process more data after type import
+                    if ($this->processAfterInsertOrUpdate($this->injectionClass, $add) === false) {
+                        $this->addCheckWarning(self::WARNING, get_class($item));
+                    }
+
+                    //$this->results['status'] = self::SUCCESS;
                     $this->results[get_class($item)] = $newID;
 
                   //Process other types
@@ -1619,7 +1620,11 @@ class PluginDatainjectionCommonInjectionLib
                             $values = $this->getValuesForItemtype($itemtype);
                             if ($this->lastCheckBeforeProcess($injectionClass, $values)) {
                                 $tmpID  = $this->effectiveAddOrUpdate($injectionClass, $item, $values, $add);
-                                $this->processAfterInsertOrUpdate($injectionClass, $add);
+                                if (!$tmpID) {
+                                    $this->addCheckWarning(self::WARNING, $itemtype);
+                                } elseif ($this->processAfterInsertOrUpdate($injectionClass, $add) === false) {
+                                    $this->addCheckWarning(self::WARNING, $itemtype);
+                                }
                             }
                         }
                     }
@@ -1627,6 +1632,20 @@ class PluginDatainjectionCommonInjectionLib
             }
         }
         return $this->results;
+    }
+
+
+    /**
+     * Flag the current line as partially injected and log the reason
+     *
+     * @param integer $code     log label describing the reason
+     * @param string  $itemtype itemtype that could not be written
+     **/
+    private function addCheckWarning(int $code, string $itemtype): void
+    {
+        $this->results['status']                     = self::WARNING;
+        $this->results[self::ACTION_CHECK]['status'] = self::WARNING;
+        $this->results[self::ACTION_CHECK][]         = [$code, $itemtype];
     }
 
 
@@ -1643,7 +1662,25 @@ class PluginDatainjectionCommonInjectionLib
     private function effectiveAddOrUpdate($injectionClass, $item, $values, $add = true)
     {
 
-       //Insert data using the standard add() method
+        //The plugin acts as the front controller here: rights must be checked before writing.
+        //Skipped without a session, as the lib is also a programmatic entry point for scripts.
+        if (Session::getLoginUserID() !== false) {
+            $input = is_array($values) ? $values : [];
+            if ($add) {
+                //Passing the input to can() makes the check cover the target entity
+                if (!$item->can(-1, CREATE, $input)) {
+                    $this->addCheckWarning(self::ERROR_CANNOT_IMPORT, get_class($item));
+                    return 0;
+                }
+
+                //On the update path the target id is known, so the per-item check also covers the entity scope
+            } elseif (!isset($values['id']) || !$item->can($values['id'], UPDATE)) {
+                $this->addCheckWarning(self::ERROR_CANNOT_UPDATE, get_class($item));
+                return 0;
+            }
+        }
+
+        //Insert data using the standard add() method
         $toinject = [];
         $options  = $injectionClass->getOptions();
 
@@ -1816,7 +1853,6 @@ class PluginDatainjectionCommonInjectionLib
                         $option,
                         $option['linkfield'],
                         $value,
-                        true
                     );
                 }
             }
@@ -2317,15 +2353,17 @@ class PluginDatainjectionCommonInjectionLib
     * @param PluginDatainjectionInjectionInterface $injectionClass the injection class to use
     * @param  $add true if an item is created, false if it's an update
     *
-    * @return void nothing
+    * @return bool false if the injection class rejected a post-processing step
    **/
     private function processAfterInsertOrUpdate($injectionClass, $add = true)
     {
 
        //If itemtype implements special process after type injection
         if (method_exists($injectionClass, 'processAfterInsertOrUpdate')) {
-           //Invoke it
-            $injectionClass->processAfterInsertOrUpdate($this->values, $add, $this->rights);
+            //Invoke it
+            return $injectionClass->processAfterInsertOrUpdate($this->values, $add, $this->rights) !== false;
         }
+
+        return true;
     }
 }

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -1357,13 +1357,25 @@ class PluginDatainjectionModel extends CommonDBTM
             }
         }
 
+        $check_add    = (bool) ($model->fields['behavior_add'] ?? 0);
+        $check_update = (bool) ($model->fields['behavior_update'] ?? 0);
+
+        //A model doing nothing still requires the creation right to be listed
+        if (!$check_add && !$check_update) {
+            $check_add = true;
+        }
+
         foreach (array_unique($itemtypes) as $itemtype) {
             if ($itemtype == PluginDatainjectionInjectionType::NO_VALUE || !is_a($itemtype, CommonDBTM::class, true)) {
                 continue;
             }
 
             $item = new $itemtype();
-            if (!$item->canCreate()) {
+            if ($check_add && !$item->canCreate()) {
+                return false;
+            }
+
+            if ($check_update && !$item->canUpdate()) {
                 return false;
             }
         }

--- a/inc/userinjection.class.php
+++ b/inc/userinjection.class.php
@@ -189,12 +189,11 @@ class PluginDatainjectionUserInjection extends User implements PluginDatainjecti
     * @param array $values
     * @param boolean $add                (true by default)
     * @param array|null $rights    array
+    *
+    * @return bool false if a post-processing step was rejected
     */
     public function processAfterInsertOrUpdate($values, $add = true, $rights = [])
     {
-        /** @var DBmysql $DB */
-        global $DB;
-
        //Manage user emails (both for add and update)
         if (
             isset($values['User']['useremails_id'])
@@ -234,13 +233,7 @@ class PluginDatainjectionUserInjection extends User implements PluginDatainjecti
             }
         }
 
-        if (isset($values['User']['password']) && ($values['User']['password'] != '')) {
-            $DB->update(
-                'glpi_users',
-                ['password' => Auth::getPasswordHash(Sanitizer::unsanitize($values['User']['password']))],
-                ['id' => $values['User']['id']],
-            );
-        }
+        return true;
     }
 
 

--- a/tests/unit/InjectionWriteRightTest.php
+++ b/tests/unit/InjectionWriteRightTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * DataInjection plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of DataInjection.
+ *
+ * DataInjection is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * DataInjection is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DataInjection. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2007-2023 by DataInjection plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/datainjection
+ * -------------------------------------------------------------------------
+ */
+
+final class InjectionWriteRightTest extends DbTestCase
+{
+    private function injectData(
+        object $injection_class,
+        array $injected_data,
+        array $mandatory_fields
+    ): array {
+        $lib = new PluginDatainjectionCommonInjectionLib(
+            $injection_class,
+            $injected_data,
+            [
+                'rights' => [
+                    'can_add'      => true,
+                    'can_update'   => true,
+                    'add_dropdown' => true,
+                ],
+                'mandatory_fields' => $mandatory_fields,
+                'entities_id'      => 0,
+            ],
+        );
+
+        $lib->processAddOrUpdate();
+
+        return $lib->getInjectionResults();
+    }
+
+    public function testInjectedUserPasswordIsUsableAndRaisesNoError(): void
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI["event_loglevel"] = 0;
+
+        $this->login();
+
+        $login    = 'test_injected_user_' . random_int(1, PHP_INT_MAX);
+        $password = 'Ohbah7ohw!aeK3';
+
+        $results = $this->injectData(
+            new PluginDatainjectionUserInjection(),
+            ['User' => ['name' => $login, 'password' => $password]],
+            ['User' => ['name' => true]],
+        );
+
+        self::assertSame(PluginDatainjectionCommonInjectionLib::SUCCESS, $results['status']);
+        self::assertEmpty($_SESSION['MESSAGE_AFTER_REDIRECT'][ERROR] ?? []);
+
+        $user = new User();
+        self::assertTrue($user->getFromDB($results['User']));
+        self::assertTrue(Auth::checkPassword($password, $user->fields['password']));
+    }
+
+    public function testInjectedUserPasswordIsUpdatedOnExistingUser(): void
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI["event_loglevel"] = 0;
+
+        $this->login();
+
+        $login        = 'test_injected_user_' . random_int(1, PHP_INT_MAX);
+        $password     = 'Ohbah7ohw!aeK3';
+        $new_password = 'Eiy4ohn!ohGh1o';
+
+        $results = $this->injectData(
+            new PluginDatainjectionUserInjection(),
+            ['User' => ['name' => $login, 'password' => $password]],
+            ['User' => ['name' => true]],
+        );
+        self::assertSame(PluginDatainjectionCommonInjectionLib::SUCCESS, $results['status']);
+
+        $results = $this->injectData(
+            new PluginDatainjectionUserInjection(),
+            ['User' => ['name' => $login, 'password' => $new_password]],
+            ['User' => ['name' => true]],
+        );
+        self::assertSame(PluginDatainjectionCommonInjectionLib::SUCCESS, $results['status']);
+        self::assertEmpty($_SESSION['MESSAGE_AFTER_REDIRECT'][ERROR] ?? []);
+
+        $user = new User();
+        self::assertTrue($user->getFromDB($results['User']));
+        self::assertTrue(Auth::checkPassword($new_password, $user->fields['password']));
+    }
+
+    public function testInjectionIsRejectedWithoutUpdateRightOnExistingItem(): void
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI["event_loglevel"] = 0;
+
+        $this->login();
+
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'Test_Computer_write_right_' . random_int(1, PHP_INT_MAX),
+            'entities_id' => 0,
+        ]);
+        $comment = $computer->fields['comment'];
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ;
+
+        $results = $this->injectData(
+            new PluginDatainjectionComputerInjection(),
+            ['Computer' => ['name' => $computer->fields['name'], 'comment' => 'Injected comment']],
+            ['Computer' => ['name' => true]],
+        );
+
+        self::assertSame(PluginDatainjectionCommonInjectionLib::WARNING, $results['status']);
+
+        self::assertTrue($computer->getFromDB($computer->getID()));
+        self::assertSame($comment, $computer->fields['comment']);
+    }
+
+    public function testInjectionIsRejectedWithoutCreateRight(): void
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI["event_loglevel"] = 0;
+
+        $this->login();
+
+        $name = 'Test_Computer_no_create_' . random_int(1, PHP_INT_MAX);
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ;
+
+        $results = $this->injectData(
+            new PluginDatainjectionComputerInjection(),
+            ['Computer' => ['name' => $name]],
+            ['Computer' => ['name' => true]],
+        );
+
+        self::assertSame(PluginDatainjectionCommonInjectionLib::WARNING, $results['status']);
+        self::assertSame(0, countElementsInTable('glpi_computers', ['name' => $name]));
+    }
+}

--- a/tests/unit/ModelCheckRightTest.php
+++ b/tests/unit/ModelCheckRightTest.php
@@ -32,15 +32,18 @@ final class ModelCheckRightTest extends DbTestCase
 {
     private function createModel(string $itemtype = Computer::class): int
     {
+        return $this->createModelWithBehaviors($itemtype, ['behavior_add' => 1, 'behavior_update' => 0]);
+    }
+
+    private function createModelWithBehaviors(string $itemtype, array $behaviors): int
+    {
         $model = new PluginDatainjectionModel();
-        $models_id = $model->add([
+        $models_id = $model->add($behaviors + [
             'name'            => 'Test_Model_CheckRight_' . $itemtype . '_' . random_int(1, PHP_INT_MAX),
             'itemtype'        => $itemtype,
             'filetype'        => 'csv',
             'entities_id'     => 0,
             'is_private'      => 0,
-            'behavior_add'    => 1,
-            'behavior_update' => 0,
             'users_id'        => Session::getLoginUserID(),
         ]);
         $this->assertGreaterThan(0, $models_id);
@@ -99,5 +102,43 @@ final class ModelCheckRightTest extends DbTestCase
         //Control model keeps its own granted itemtype: only the mapped relation may deny
         $this->assertTrue(PluginDatainjectionModel::checkRightOnModel($control_id));
         $this->assertFalse(PluginDatainjectionModel::checkRightOnModel($models_id));
+    }
+
+    public function testUpdateEnabledModelIsDeniedWithCreateRightOnly(): void
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI["event_loglevel"] = 0;
+
+        $this->login();
+
+        $models_id = $this->createModelWithBehaviors(
+            Computer::class,
+            ['behavior_add' => 0, 'behavior_update' => 1],
+        );
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = CREATE;
+        $this->assertFalse(PluginDatainjectionModel::checkRightOnModel($models_id));
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = CREATE | UPDATE;
+        $this->assertTrue(PluginDatainjectionModel::checkRightOnModel($models_id));
+    }
+
+    public function testAddOnlyModelIsDeniedWithUpdateRightOnly(): void
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI["event_loglevel"] = 0;
+
+        $this->login();
+
+        $models_id = $this->createModelWithBehaviors(
+            Computer::class,
+            ['behavior_add' => 1, 'behavior_update' => 0],
+        );
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = UPDATE;
+        $this->assertFalse(PluginDatainjectionModel::checkRightOnModel($models_id));
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = CREATE;
+        $this->assertTrue(PluginDatainjectionModel::checkRightOnModel($models_id));
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Backport for https://github.com/pluginsGLPI/datainjection/pull/664

- A model allowed to update existing items was accepted as soon as the user held the creation right on the imported itemtypes, so an import could rewrite items the profile is not allowed to modify.
- The required right is now derived from what the model is actually allowed to do: creation right for a model that adds lines, update right for a model that updates lines, and the same right is verified again just before each write.
- Imported user passwords were written directly in the database, which skipped the configured password policy, left the password expiration date unchanged and logged nothing in the item history.
- Passwords are now set through the standard user update, so the policy, the expiration date and the history all apply.


## Screenshots (if appropriate):
